### PR TITLE
jsonknife bundle, --flavor option

### DIFF
--- a/dictknife/commands/jsonknife.py
+++ b/dictknife/commands/jsonknife.py
@@ -81,17 +81,15 @@ def bundle(
     input_format: str,
     output_format: str,
     format: str,
+    flavor: str,
     extras: list = None
 ):
     from dictknife.jsonknife import bundle
 
     if ref is not None:
-        src = "{prefix}#/{name}".format(prefix=src, name=ref.lstrip('#/'))
-    loading.dumpfile(
-        bundle(src, format=input_format or format, extras=extras),
-        dst,
-        format=output_format or format,
-    )
+        src = "{prefix}#/{name}".format(prefix=src, name=ref.lstrip("#/"))
+    result = bundle(src, format=input_format or format, extras=extras, flavor=flavor)
+    loading.dumpfile(result, dst, format=output_format or format)
 
 
 def examples(
@@ -186,6 +184,7 @@ def main():
     sparser.add_argument("--src", default=None)
     sparser.add_argument("--dst", default=None)
     sparser.add_argument("--ref", default=None)
+    sparser.add_argument("--flavor", choices=["openapiv3", "openapiv2"], default="openapiv3")
     sparser.add_argument("-f", "--format", default=None, choices=formats)
     sparser.add_argument("-i", "--input-format", default=None, choices=formats)
     sparser.add_argument("-o", "--output-format", default=None, choices=formats)

--- a/dictknife/jsonknife/__init__.py
+++ b/dictknife/jsonknife/__init__.py
@@ -1,5 +1,5 @@
 from .expander import Expander  # noqa
-from .bundler import Bundler  # noqa
+from .bundler import Bundler, create_scanner_factory_from_flavor  # noqa
 from .resolver import (  # noqa
     get_resolver,
     get_resolver_from_filename,  # backward compatibility
@@ -21,7 +21,9 @@ def expand(filename, *, onload=None, doc=None, format=None):
     return expander.expand()
 
 
-def bundle(filename, *, onload=None, doc=None, format=None, extras=None):
+def bundle(
+    filename, *, onload=None, doc=None, format=None, extras=None, flavor="openapiv2"
+):
     jsonref = ""
     if filename:
         filename, jsonref = pairrsplit(filename, "#/")
@@ -52,6 +54,8 @@ def bundle(filename, *, onload=None, doc=None, format=None, extras=None):
             assign_by_json_pointer(doc, ejsonref, {"$ref": eref})
 
     resolver = get_resolver(filename, doc=doc, onload=onload, format=format)
-    bundler = Bundler(resolver)
+    bundler = Bundler(
+        resolver, scanner_factory=create_scanner_factory_from_flavor(flavor)
+    )
     r = bundler.bundle(resolver.doc)
     return r

--- a/dictknife/jsonknife/bundler.py
+++ b/dictknife/jsonknife/bundler.py
@@ -1,6 +1,7 @@
 import logging
 import os.path
 from collections import defaultdict
+from functools import partial
 
 from dictknife.langhelpers import make_dict, titleize, reify, pairrsplit
 from dictknife import DictWalker
@@ -13,16 +14,35 @@ from .accessor import CachedItemAccessor
 logger = logging.getLogger("jsonknife.bundler")
 
 
+def create_scanner_factory_from_flavor(flavor: str):
+    # thid is temporary, implementation
+    if flavor == "openapiv2":
+        return partial(
+            Scanner, localref_fixer=LocalrefFixer(default_position="definitions")
+        )
+    elif flavor == "openapiv3":
+        return partial(
+            Scanner, localref_fixer=LocalrefFixer(default_position="components/schema")
+        )
+    else:
+        raise ValueError(
+            "unexpected flavor {!r}, available flavors are ['openapiv2', 'openapiv3']".format(
+                flavor
+            )
+        )
+
+
 class Bundler:
-    def __init__(self, resolver, strict=False):
+    def __init__(self, resolver, strict=False, *, scanner_factory=None):
         self.resolver = resolver
         self.accessor = CachedItemAccessor(resolver)
         self.item_map = make_dict()  # localref -> item
         self.strict = strict
+        self._scanner_factory = scanner_factory or Scanner
 
     @reify
     def scanner(self):
-        return Scanner(self.accessor, self.item_map, strict=self.strict)
+        return self._scanner_factory(self.accessor, self.item_map, strict=self.strict)
 
     @reify
     def emitter(self):
@@ -35,11 +55,16 @@ class Bundler:
 
 
 class Scanner:
-    def __init__(self, accessor, item_map, strict=False):
+    def __init__(self, accessor, item_map, strict=False, localref_fixer=None):
         self.accessor = accessor
         self.item_map = item_map
         self.strict = strict
         self.seen = set()
+
+        # todo: rename
+        self.localref_fixer = localref_fixer or LocalrefFixer(
+            default_position="definitions"
+        )
 
     @reify
     def ref_walking(self):
@@ -48,10 +73,6 @@ class Scanner:
     @reify
     def conflict_fixer(self):  # todo: rename
         return SimpleConflictFixer(self.item_map, strict=self.strict)
-
-    @reify
-    def localref_fixer(self):  # todo: rename
-        return LocalrefFixer()
 
     def scan(self, doc):
         conflicted = defaultdict(list)
@@ -164,6 +185,9 @@ class Emitter:
 
 
 class LocalrefFixer:  # todo: rename
+    def __init__(self, *, default_position: str) -> None:
+        self.default_position = default_position
+
     def guess_name(self, path, item):
         name = pairrsplit(item.globalref[1], "/")[1]
         if name:
@@ -177,7 +201,8 @@ class LocalrefFixer:  # todo: rename
 
         prefix, name = pairrsplit(localref, "/")
         if not prefix:
-            prefix = "definitions"  # xxx:
+            # xxx: "definitions" or "components/schemas"?
+            prefix = self.default_position
         if not name:
             name = self.guess_name(path, item)
 

--- a/dictknife/jsonknife/bundler.py
+++ b/dictknife/jsonknife/bundler.py
@@ -236,7 +236,7 @@ class SimpleConflictFixer:  # todo: rename
             raise RuntimeError(
                 "conficted. %r <-> %r" % (olditem.globalref, newitem.globalref)
             )
-        logger.info("conficted. %r <-> %r", (olditem.globalref, newitem.globalref))
+        logger.info("conficted. %r <-> %r", olditem.globalref, newitem.globalref)
 
         if olditem.globalref[0] != newitem.globalref[0]:
             dirpath, name = pairrsplit(newitem.localref, "/")

--- a/dictknife/swaggerknife/migration.py
+++ b/dictknife/swaggerknife/migration.py
@@ -5,7 +5,7 @@ import tempfile
 import shutil
 from collections import ChainMap
 
-from dictknife.jsonknife.bundler import Scanner, CachedItemAccessor
+from dictknife.jsonknife.bundler import Scanner, CachedItemAccessor, LocalrefFixer
 from dictknife.langhelpers import make_dict, reify
 from dictknife.jsonknife import json_pointer_to_path
 from dictknife.diff import diff
@@ -58,7 +58,12 @@ class Migration:
     def _prepare(self, *, doc, where):
         logger.debug("prepare (where=%s)", where)
         accessor = CachedItemAccessor(self.resolver)
-        scanner = Scanner(accessor, self.item_map, strict=True)
+        scanner = Scanner(
+            accessor,
+            self.item_map,
+            strict=True,
+            localref_fixer=LocalrefFixer(default_position="components/schemas"),
+        )
         scanner.scan(self.resolver.doc)
 
     @contextlib.contextmanager

--- a/examples/jsonknife/bundle/Makefile
+++ b/examples/jsonknife/bundle/Makefile
@@ -53,4 +53,4 @@ dst:
 06: dst
 	mkdir -p dst/${DIR}
 	jsonknife ${OPTS} bundle --src src/${DIR}/main.yaml --dst dst/${DIR}/bundle.yaml
-
+	jsonknife ${OPTS} bundle --flavor=openapiv2 --src src/${DIR}/main.v2.yaml --dst dst/${DIR}/bundle.v2.yaml

--- a/examples/jsonknife/bundle/dst/06reffile/bundle.v2.yaml
+++ b/examples/jsonknife/bundle/dst/06reffile/bundle.v2.yaml
@@ -1,0 +1,8 @@
+definitions:
+  user:
+    type: object
+    propreties:
+      name:
+        type: string
+      age:
+        type: integer

--- a/examples/jsonknife/bundle/dst/06reffile/bundle.yaml
+++ b/examples/jsonknife/bundle/dst/06reffile/bundle.yaml
@@ -1,8 +1,12 @@
-definitions:
-  user:
-    type: object
-    propreties:
-      name:
-        type: string
-      age:
-        type: integer
+components:
+  schemas:
+    user:
+      $ref: '#/components/schema/user'
+  schema:
+    user:
+      type: object
+      propreties:
+        name:
+          type: string
+        age:
+          type: integer

--- a/examples/jsonknife/bundle/src/06reffile/main.v2.yaml
+++ b/examples/jsonknife/bundle/src/06reffile/main.v2.yaml
@@ -1,0 +1,3 @@
+definitions:
+  user:
+    $ref: "user.yaml"

--- a/examples/jsonknife/bundle/src/06reffile/main.yaml
+++ b/examples/jsonknife/bundle/src/06reffile/main.yaml
@@ -1,3 +1,4 @@
-definitions:
-  user:
-    $ref: "user.yaml"
+components:
+  schemas:
+    user:
+      $ref: "user.yaml"


### PR DESCRIPTION
in openapi v2, schema's default position is "#/defintions", othwerwise, in v3, schema's default position is "#/components/schemas"

```console
$ jsonknife bundle --src main.yaml --dst bundle.yaml --flavor openapiv2
```

default is openapiv3