### PR TITLE
fix: jsonknife, raised error's attributes are lost

### DIFF
--- a/dictknife/jsonknife/accessor.py
+++ b/dictknife/jsonknife/accessor.py
@@ -149,9 +149,11 @@ class StackedAccessor:
             where = None
             if len(self.stack) > 1:
                 where = self.stack[-2].name
-            raise e.__class__("{} (where={})".format(e, where)).with_traceback(
+            exc = e.__class__("{} (where={})".format(e, where)).with_traceback(
                 e.__traceback__
-            ) from None
+            )
+            exc.__dict__.update(e.__dict__)  # sync
+            raise exc from None
 
     def _access(self, subresolver, pointer):
         return access_by_json_pointer(subresolver.doc, pointer, accessor=self.accessor)

--- a/dictknife/jsonknife/resolver.py
+++ b/dictknife/jsonknife/resolver.py
@@ -81,6 +81,7 @@ class ExternalFileResolver(AccessingMixin):
                 exc = e.__class__("{} (where={})".format(e, self.name)).with_traceback(
                     e.__traceback__
                 )
+                exc.__dict__.update(e.__dict__)  # sync
             except Exception:
                 raise e from None
             raise exc from None


### PR DESCRIPTION
some attributes are lost.

e.g.  `context_mark` of  YAML's MarkedYAMLError