### PR TITLE
fix: use pyyaml's sort_keys option, instead of custom implementation

### DIFF
--- a/dictknife/loading/_yaml.py
+++ b/dictknife/loading/_yaml.py
@@ -1,7 +1,8 @@
-import yaml
 import re
 from collections import defaultdict, ChainMap, OrderedDict
 from dictknife.langhelpers import make_dict
+import yaml
+from yaml.representer import SafeRepresenter
 
 load = yaml.load
 dump = yaml.dump
@@ -20,11 +21,6 @@ class Loader(yaml.Loader):
 
 
 def setup(Loader, Dumper, dict_classes=[defaultdict, ChainMap, OrderedDict]):
-    def _represent_odict(dumper, instance):
-        return dumper.represent_mapping(
-            "tag:yaml.org,2002:map", dumper._iterate_dict(instance)
-        )
-
     def _construct_odict(loader, node):
         return make_dict(loader.construct_pairs(node))
 
@@ -40,5 +36,5 @@ def setup(Loader, Dumper, dict_classes=[defaultdict, ChainMap, OrderedDict]):
 
     Loader.add_constructor("tag:yaml.org,2002:map", _construct_odict)
     for dict_class in dict_classes:
-        Dumper.add_representer(dict_class, _represent_odict)
+        Dumper.add_representer(dict_class, SafeRepresenter.represent_dict)
     Dumper.add_representer(str, _represent_str)

--- a/dictknife/loading/_yaml.py
+++ b/dictknife/loading/_yaml.py
@@ -15,11 +15,6 @@ class Dumper(yaml.Dumper):
         return True
 
 
-class SortedDumper(Dumper):
-    def _iterate_dict(self, d):
-        return sorted(d.items())
-
-
 class Loader(yaml.Loader):
     pass
 

--- a/dictknife/loading/yaml.py
+++ b/dictknife/loading/yaml.py
@@ -7,7 +7,11 @@ def load(fp, *, loader=None, errors=None, **kwargs):
 
 
 def dump(d, fp, *, sort_keys=False):
-    dumper_class = m.yaml.SortedDumper if sort_keys else m.yaml.Dumper
     return m.yaml.dump(
-        d, fp, allow_unicode=True, default_flow_style=False, Dumper=dumper_class
+        d,
+        fp,
+        allow_unicode=True,
+        default_flow_style=False,
+        Dumper=m.yaml.Dumper,
+        sort_keys=sort_keys,
     )


### PR DESCRIPTION
fix #161 