### PR TITLE
doc: Add initial API documentation for core modules

### DIFF
--- a/docs/apidoc/accessing.md
+++ b/docs/apidoc/accessing.md
@@ -1,0 +1,174 @@
+```markdown
+# `dictknife.accessing`
+
+このモジュールは、ネストされた辞書やリストへのアクセス、値の割り当て、存在確認などを容易にするためのユーティリティを提供します。
+
+## `Accessor` クラス
+
+辞書やリストへの柔軟なアクセスを提供します。
+
+### `__init__(self, make_dict=make_dict, zero_value=None)`
+
+*   `make_dict`: ネストされた辞書を作成する際のファクトリ関数。デフォルトは `dictknife.langhelpers.make_dict` (通常は `OrderedDict` を返します)。
+*   `zero_value`: リストの存在しないインデックスに割り当てる際に、間の要素を埋めるためのデフォルト値。デフォルトは `None`。
+
+### `assign(self, d, path, value)`
+
+辞書 `d` の `path` (キー/インデックスのリスト) で指定された場所に `value` を割り当てます。途中の辞書やリストが存在しない場合は自動的に作成します。
+
+**実行例:**
+
+```python
+from dictknife.accessing import Accessor
+from dictknife.langhelpers import make_dict
+
+a = Accessor(make_dict=make_dict)
+data = make_dict()
+
+# 基本的な割り当て
+a.assign(data, ["name"], "Alice")
+# data is {'name': 'Alice'}
+
+# ネストした辞書への割り当て
+a.assign(data, ["address", "city"], "Tokyo")
+# data is {'name': 'Alice', 'address': {'city': 'Tokyo'}}
+
+# リストへの割り当て (インデックスが存在しない場合)
+a.assign(data, ["tags", 0], "tag1")
+# data is {'name': 'Alice', 'address': {'city': 'Tokyo'}, 'tags': ['tag1']}
+a.assign(data, ["tags", 2], "tag3")
+# data is {'name': 'Alice', 'address': {'city': 'Tokyo'}, 'tags': ['tag1', None, 'tag3']}
+
+# zero_value を指定した場合
+a_custom_zero = Accessor(make_dict=make_dict, zero_value="DEFAULT")
+data_custom = make_dict()
+a_custom_zero.assign(data_custom, ["values", 2], "val2")
+# data_custom is {'values': ['DEFAULT', 'DEFAULT', 'val2']}
+
+
+# リスト内の辞書への割り当て
+a.assign(data, ["items", 0, "id"], 101)
+# data is {..., 'items': [{'id': 101}]}
+```
+
+### `access(self, d, path)`
+
+辞書 `d` の `path` で指定された値を取得します。パスが存在しない場合は `KeyError` や `IndexError` が発生します。
+
+**実行例:**
+
+```python
+val = a.access(data, ["address", "city"])
+# val is "Tokyo"
+
+try:
+    a.access(data, ["address", "zipcode"])
+except KeyError:
+    print("zipcode not found")
+```
+
+### `maybe_access(self, d, path, *, default=None)`
+
+辞書 `d` の `path` で指定された値を取得します。パスが存在しない場合は `default` 値を返します。
+
+**実行例:**
+
+```python
+zipcode = a.maybe_access(data, ["address", "zipcode"], default="N/A")
+# zipcode is "N/A"
+```
+
+### `exists(self, d, path)`
+
+辞書 `d` の `path` で指定された要素が存在するかどうかを `bool` で返します。
+
+**実行例:**
+
+```python
+if a.exists(data, ["items", 0, "id"]):
+    print("Item ID exists")
+```
+
+### `maybe_remove(self, d, path)`
+
+辞書 `d` の `path` で指定された要素を削除します。要素が存在しない場合は何もしません。
+
+**実行例:**
+
+```python
+a.maybe_remove(data, ["tags", 1]) # 'tags' のインデックス1 (None) を削除
+# data is {..., 'tags': ['tag1', 'tag3']}
+```
+
+## `Scope` クラス
+
+階層的なスコープを持つ設定値へのアクセスを提供します。複数の辞書をスタックとして扱い、値の検索はスタックの上から行われます。
+
+### `__init__(self, init=None, *, accessor=None)`
+
+*   `init`: 初期状態の辞書。
+*   `accessor`: 使用する `Accessor` インスタンス。
+
+### `get(self, path, default=None)`
+
+現在のスコープスタックを探索し、`path` に対応する最初の値を取得します。見つからない場合は `default` を返します。
+
+### `push(self, state)` / `pop(self)`
+
+スコープスタックに新しい状態 (辞書) を追加/削除します。
+
+### `scope(self, d=None)`
+
+`with` 文と組み合わせて使用できるコンテキストマネージャ。ブロック内でのみ `d` をスコープスタックに追加します。
+
+**実行例:**
+
+```python
+from dictknife.accessing import Scope
+
+base_config = {"color": "blue", "size": 10}
+scope = Scope(base_config)
+
+print(scope.get(["color"]))  # "blue"
+
+with scope.scope({"color": "red", "font": "Arial"}):
+    print(scope.get(["color"]))  # "red" (現在のスコープから)
+    print(scope.get(["size"]))   # 10 (ベーススコープから)
+    print(scope.get(["font"]))   # "Arial" (現在のスコープから)
+
+print(scope.get(["color"]))  # "blue" (スコープを抜けたので元に戻る)
+```
+
+## `dictmap(fn, x, *, mutable=False, with_key=False)` 関数
+
+辞書やリスト `x` の各要素に再帰的に関数 `fn` を適用します。
+
+*   `fn`: 各要素に適用する関数。
+*   `x`: 対象の辞書またはリスト。
+*   `mutable=False` (デフォルト): 非破壊的。新しいオブジェクトを返します。`True` にすると元のオブジェクトを変更します。
+*   `with_key=False` (デフォルト): `False` なら値のみに `fn` を適用。`True` なら辞書のキーと値の両方に `fn` を適用します。
+
+**実行例:**
+
+```python
+from dictknife.accessing import dictmap
+
+data = {"a": 1, "b": {"c": 2, "d": [3, 4]}}
+
+# 値をすべて文字列に変換 (非破壊的)
+str_data = dictmap(str, data)
+# str_data is {'a': '1', 'b': {'c': '2', 'd': ['3', '4']}}
+
+# 値を2倍にする (破壊的)
+def double_if_int(v):
+    if isinstance(v, int):
+        return v * 2
+    return v
+dictmap(double_if_int, data, mutable=True)
+# data is {'a': 2, 'b': {'c': 4, 'd': [6, 8]}}
+```
+
+## `ImmutableModifier` / `MutableModifier` クラス
+
+`dictmap` が内部で使用するクラスで、リストや辞書の再帰的な操作を非破壊的または破壊的に行うためのメソッドを提供します。通常、直接使用する必要はありません。
+```

--- a/docs/apidoc/cliutils_extraarguments.md
+++ b/docs/apidoc/cliutils_extraarguments.md
@@ -1,0 +1,73 @@
+```markdown
+# `dictknife.cliutils.extraarguments`
+
+このモジュールは、Pythonの `argparse` を拡張し、特定のオプションの値に応じて動的に変化する「追加の引数 (extra arguments)」をパースする仕組みを提供します。
+
+例えば、`mycommand --format json --json-sort-keys` のように、`--format` オプションの値が `json` である場合にのみ `--json-sort-keys` という追加オプションを有効にしたい、といったシナリオで使用されます。`dictknife` のコマンドラインツールでは、出力フォーマット (`--format yaml` など) に応じて、そのフォーマット固有のオプション (例: YAMLのインデント設定) を受け付けるために利用されています。
+
+## `ExtraArgumentsParsers` クラス
+
+メインとなる `argparse.ArgumentParser` にバインドし、追加引数の定義とパースを管理します。
+
+### `__init__(self, parser, dest, *, prefix="extra", parser_factory=argparse.ArgumentParser)`
+
+*   `parser`: メインとなる `argparse.ArgumentParser` インスタンス。
+*   `dest`: 追加引数が関連付けられるメインパーサーのオプション名 (例: `--format` オプションの場合、`dest` は通常 `"format"`)。
+*   `prefix="extra"` (デフォルト): 追加引数をコマンドラインで指定する際のプレフィックス。例えば `prefix="extra"` の場合、追加引数 `sort_keys` は `--extra-sort-keys` として指定します。
+*   `parser_factory=argparse.ArgumentParser`: 追加引数用の内部パーサーを生成するためのファクトリ。
+
+初期化時に、メインパーサーのヘルプメッセージ生成機能 (`format_help`) が拡張され、定義された追加引数のヘルプも表示されるようになります。
+
+### `add_parser(self, name)`
+
+`dest` オプションが取りうる特定の値 `name` (例: `"json"`, `"yaml"`) に対応する追加引数用の新しい `ArgumentParser` インスタンスを作成し、返します。
+返されたパーサーに対して、通常の `argparse` と同様に `add_argument()` を使って、その `name` が選択された場合にのみ有効になる引数を定義できます。
+
+**例:**
+```python
+main_parser = ArgumentParser("mycmd")
+main_parser.add_argument("--output-format", default="json", choices=["json", "yaml"])
+
+extra_parsers = ExtraArgumentsParsers(main_parser, dest="output_format", prefix="format")
+
+# "--output-format json" の時だけ有効なオプション
+json_extra_parser = extra_parsers.add_parser("json")
+json_extra_parser.add_argument("--sort-keys", action="store_true", help="JSON出力でキーをソートする")
+json_extra_parser.add_argument("--indent", type=int, help="JSON出力のインデント数")
+
+# "--output-format yaml" の時だけ有効なオプション
+yaml_extra_parser = extra_parsers.add_parser("yaml")
+yaml_extra_parser.add_argument("--default-flow-style", action="store_false", help="YAML出力のデフォルトフロースタイル")
+```
+
+### `parse_args(self, name, args)`
+
+指定された `name` (例: `"json"`) に対応する追加引数パーサーを使って、`args` (追加引数のリスト、例: `['--format-sort-keys', '--format-indent', '2']`) をパースします。
+
+*   `name`: `dest` オプションが取った値。
+*   `args`: パース対象の追加引数文字列のリスト。プレフィックス (`--<prefix>-`) が付いている必要があります。
+*   パースされた結果 (名前空間オブジェクト) を返します。
+*   定義されていない追加引数が `args` に含まれていた場合、警告を標準エラーに出力して無視します。
+
+### ヘルプメッセージの拡張
+
+`ExtraArgumentsParsers` をバインドすると、メインパーサーのヘルプメッセージ (`python mycmd.py -h`) に、以下のように追加引数の説明が自動的に付加されます。
+
+```
+usage: mycmd [-h] [--output-format {json,yaml}] ...
+
+options:
+  -h, --help            show this help message and exit
+  --output-format {json,yaml}
+
+format arguments: (with --format-<option>)
+  for output_format=json:
+    --sort-keys       JSON出力でキーをソートする
+    --indent INDENT   JSON出力のインデント数
+  for output_format=yaml:
+    --default-flow-style
+                        YAML出力のデフォルトフロースタイル
+```
+
+これにより、ユーザーは特定のオプション選択時に利用可能な追加オプションを容易に知ることができます。
+```

--- a/docs/apidoc/commands_dictknife.md
+++ b/docs/apidoc/commands_dictknife.md
@@ -1,0 +1,170 @@
+```markdown
+# `dictknife` コマンド
+
+`dictknife` コマンドラインツールは、JSON、YAML、TOMLなどの構造化データを扱うための多機能ツールです。データのマージ、変換、差分表示、構造解析など、様々な操作を行えます。
+
+## グローバルオプション
+
+これらのオプションは、全てのサブコマンドに共通して (または多くの場合に) 利用可能です。
+
+*   `--log {DEBUG,INFO,WARNING,ERROR,CRITICAL}`: ログレベルを設定します。デフォルトは `INFO`。
+*   `-q, --quiet`: 警告を抑制し、ログレベルを `WARNING` にします。
+*   `--debug`: デバッグモード。エラー発生時に簡潔なトレースバックを表示します。
+*   `--compact`: (主にJSON出力時) インデントなしのコンパクトな形式で出力します。
+*   `--flatten`: データをフラット化します (詳細は `dictknife.loading.modification.flatten` を参照)。ロード時に適用されます。
+*   `--unescape {unicode,url}`: Unicodeエスケープシーケンス (`\uXXXX`) やURLエンコードされた文字列をデコードします。ロード時に適用されます。
+
+## サブコマンド
+
+### `cat`
+
+複数のファイルを読み込み、マージして単一のドキュメントとして出力します。
+
+**主なオプション:**
+
+*   `files`: 入力ファイル名のリスト。省略すると標準入力から読み込みます。
+*   `--dst <filepath>`: 出力ファイルパス。省略すると標準出力。
+*   `-f, --format <fmt>`: 入出力のデフォルトフォーマット (例: `json`, `yaml`, `toml`)。
+*   `-i, --input-format <fmt>`: 入力フォーマットを明示的に指定。
+*   `-o, --output-format <fmt>`: 出力フォーマットを明示的に指定。
+*   `--slurp`: 各入力ファイルを1行ずつ読み込み、それぞれを個別のドキュメントとして扱ってマージします (主にJSON Lines形式などで使用)。
+*   `--size <int>`: 各ファイルから読み込むドキュメント数を制限します (`--slurp` と併用)。
+*   `--encoding <enc>`: 入力ファイルのエンコーディング。
+*   `--errors <handler>`: エンコーディングエラーの処理方法 (`strict`, `ignore` など)。
+*   `-S, --sort-keys`: 出力時にキーをソートします (主にJSONやYAML出力時)。
+*   `--merge-method {addtoset,append,merge,replace}`: 複数の入力ファイルをマージする際の戦略。デフォルトは `addtoset`。詳細は `dictknife.deepmerge` を参照。
+*   フォーマット固有オプション: (例: `--yaml-default-flow-style`) `dictknife.cliutils.extraarguments` を通じて、選択されたフォーマットに応じた追加オプションが利用可能です。
+
+**実行例:**
+
+```bash
+# config1.yml と config2.json をマージして result.json に出力
+dictknife cat config1.yml config2.json -o result.json --output-format json
+
+# 標準入力からYAMLを読み込み、キーをソートしてJSONで標準出力
+cat data.yaml | dictknife cat -f yaml -o - --output-format json -S
+```
+
+### `transform`
+
+入力データに対してPythonコードや定義済みの変換関数を適用し、結果を出力します。
+
+**主なオプション:**
+
+*   `src`: 入力ファイル名。省略すると標準入力。
+*   `--dst <filepath>`: 出力ファイルパス。省略すると標準出力。
+*   `--code <python_expr>`: データ `d` を引数とするPythonの式 (ラムダ式など) で変換処理を定義。例: `--code "lambda d: {k.upper(): v for k, v in d.items()}"`
+*   `--fn <name_or_path>`, `--function <name_or_path>` (複数指定可):
+    *   `dictknife.transform` モジュール内の関数名 (例: `flatten`, `squash_keys`)。
+    *   または `<module>:<function_name>` 形式 (例: `my_transforms:custom_func`)。
+    *   複数指定した場合、順番に適用されます。
+*   `-i, --input-format <fmt>`, `-o, --output-format <fmt>`, `-f, --format <fmt>`: フォーマット指定。
+*   `-S, --sort-keys`: 出力時のキーソート。
+
+**実行例:**
+
+```bash
+# data.json の全キーを大文字に変換
+dictknife transform data.json --code "lambda d: {k.upper(): v for k, v in d.items()}"
+
+# data.yaml の値を全て文字列に変換し、その後キーをフラット化
+dictknife transform data.yaml --fn "lambda d: dictmap(str, d)" --fn flatten -o flattened_data.json
+```
+
+### `diff`
+
+2つのファイルの内容を比較し、差分を表示します。
+
+**主なオプション:**
+
+*   `left`: 比較対象の左側のファイル。
+*   `right`: 比較対象の右側のファイル。
+*   `--normalize`: 比較前にデータを正規化 (順序不問の比較)。詳細は `dictknife.deepequal.sort_flexibly` を参照。
+*   `--n <int>`: (unified diff形式の場合) 変更箇所の前後コンテキスト行数。デフォルトは3。
+*   `--skip-empty`: (`dict`, `md`などの行ベース出力時) 差分のない行をスキップします。
+*   `-i, --input-format <fmt>`: 入力フォーマット。
+*   `-o, --output-format {diff,dict,md,tsv,jsonpatch,pair}`: 出力フォーマット。
+    *   `diff` (デフォルト): 標準的なunified diff形式。
+    *   `jsonpatch`: RFC6902 JSON Patch形式。
+    *   `pair`: 左右のファイルを整形して並べて表示。
+    *   その他 (`dict`, `md`, `tsv`): `dictknife.diff.rows` による行ごとの差分情報。
+*   `-S, --sort-keys`: (主に `pair` や `jsonpatch` の内部JSON変換時) キーをソート。
+*   `--verbose`: (`jsonpatch` 出力時) 詳細な差分情報を追加。
+
+**実行例:**
+
+```bash
+# file1.json と file2.json の差分をunified diffで表示
+dictknife diff file1.json file2.json
+
+# file1.yaml と file2.yaml の差分をJSON Patch形式で表示 (正規化あり)
+dictknife diff file1.yaml file2.yaml --normalize -o jsonpatch
+```
+
+### `shape`
+
+入力データの構造 (キーのパス、型、具体例など) を解析し、表示します。スキーマの自動生成やデータ理解に役立ちます。
+
+**主なオプション:**
+
+*   `files`: 入力ファイル名のリスト。省略すると標準入力。
+*   `--squash`: 複数の入力ファイルを1つのデータセットとして扱って解析します。
+*   `--skiplist`: リストの要素を個別に解析せず、リスト自体を1つの型として扱います。
+*   `--full`: 例 (example) を省略せずに表示します (通常は大きなリストや辞書は省略される)。
+*   `--with-type`: 型情報を表示します。
+*   `--with-example`: 具体例を表示します。
+*   `--separator <char>`: 出力されるパスの区切り文字。デフォルトは `/`。
+*   `-i, --input-format <fmt>`, `-o, --output-format <fmt>`: フォーマット指定。出力フォーマットを指定しない場合はプレーンテキストで標準出力。
+
+**実行例:**
+
+```bash
+# data.json の構造を解析し、型と例を表示
+dictknife shape data.json --with-type --with-example -o shape_summary.csv --output-format csv
+```
+
+### `shrink`
+
+大きなデータ構造 (長い文字列や多数の要素を持つリスト) を、指定された長さに縮小して表示します。巨大なデータの概要を把握するのに便利です。
+
+**主なオプション:**
+
+*   `files`: 入力ファイル名のリスト。省略すると標準入力。
+*   `--max-length-of-string <int>`: 文字列の最大表示長。デフォルトは100。
+*   `--max-length-of-list <int>`: リストの最大表示要素数。デフォルトは3。
+*   `--cont-suffix <str>`: 省略時に付加する接尾辞。デフォルトは `...`。
+*   `--with-tail`: リストを省略する際に、先頭要素だけでなく末尾の要素も表示します。
+*   `-i, --input-format <fmt>`, `-o, --output-format <fmt>`: フォーマット指定。
+
+**実行例:**
+
+```bash
+# large_data.json の文字列を20文字、リストを2要素に縮小して表示
+dictknife shrink large_data.json --max-length-of-string 20 --max-length-of-list 2 -o shrunk_data.json
+```
+
+### `mkdict`
+
+シンプルなキーバリュー形式のテキスト (標準入力またはコマンドライン引数) から辞書を生成します。
+
+**主なオプション:**
+
+*   入力は標準入力から1行1定義、またはコマンドライン引数の末尾に `key=value` や `key/subkey=value` の形式で与えます。
+*   `--squash`: 各入力行から生成された辞書を、個別のドキュメントとして出力します (JSON Linesのような形式)。
+*   `-o, --output-format <fmt>`: 出力フォーマット。デフォルトは `json`。
+*   `--separator <char>`: ネストしたキーの区切り文字。デフォルトは `/` (例: `path/to/key=value`)。
+*   `--delimiter <char>`: (現在明確な用途不明)
+*   `-S, --sort-keys`: 出力時のキーソート。
+
+**実行例:**
+
+```bash
+# 標準入力から辞書を生成
+echo "name=test" | dictknife mkdict -o - --output-format yaml
+# name: test
+
+# コマンドライン引数からネストした辞書を生成
+dictknife mkdict user/name=Alice user/age=30 -o user.json
+# user.json の内容: {"user": {"name": "Alice", "age": 30}}
+```
+```

--- a/docs/apidoc/commands_jsonknife.md
+++ b/docs/apidoc/commands_jsonknife.md
@@ -1,0 +1,122 @@
+```markdown
+# `jsonknife` コマンド
+
+`jsonknife` コマンドラインツールは、JSON (およびYAMLなど `dictknife` が扱える形式) ドキュメント、特にJSON Reference (`$ref`) を含むOpenAPI/Swaggerのようなスキーマファイルを扱うための特化した機能を提供します。
+
+## グローバルオプション
+
+*   `--log {DEBUG,INFO,WARNING,ERROR,CRITICAL}`: ログレベル。
+*   `-q, --quiet`: 警告抑制。
+*   `--debug`: デバッグモード。
+
+## サブコマンド
+
+### `cut`
+
+JSONドキュメントから、指定されたJSON Pointerの要素を削除します。
+
+**主なオプション:**
+
+*   `--src <filepath>`: 入力ファイル。
+*   `--dst <filepath>`: 出力ファイル。省略すると標準出力。
+*   `--ref <JSON Pointer>` (複数指定可): 削除する要素をJSON Pointer (例: `#/definitions/User`, `/paths/~1users/get`) で指定します。
+
+**実行例:**
+
+```bash
+# schema.json から definitions/OldApi と paths/~1old~1endpoint を削除
+jsonknife cut --src schema.json --ref "#/definitions/OldApi" --ref "/paths/~1old~1endpoint" -o cleaned_schema.json
+```
+
+### `select` (旧 `deref`)
+
+JSONドキュメント内のJSON Reference (`$ref`) を解決し、指定された部分または全体を展開 (dereference/expand) して出力します。
+
+**主なオプション:**
+
+*   `--src <filepath_or_uri>`: 入力ファイルまたはURI。
+*   `--dst <filepath>`: 出力ファイル。省略すると標準出力。
+*   `--ref <JSON Pointer>[@<new_pointer>]` (複数指定可):
+    *   展開する対象をJSON Pointerで指定します。
+    *   `@<new_pointer>` を付けると、展開結果を指定した新しいJSON Pointerの位置に配置します。省略すると、元の構造に基づいてマージされます。
+*   `--unwrap <JSON Pointer>`: 指定したJSON Pointerの部分のみを展開して出力します。`--ref` が指定されていない場合、この値が最初の `--ref` として扱われます。
+*   `--wrap <JSON Pointer>`: 展開結果全体を、指定したJSON Pointerの下に配置します。
+*   `-f, --format <fmt>`, `-i, --input-format <fmt>`, `-o, --output-format <fmt>`: フォーマット指定。
+
+**実行例:**
+
+```bash
+# openapi.yaml 内の全ての $ref を解決して展開
+jsonknife select --src openapi.yaml -o resolved.yaml
+
+# my_schema.json の #/components/schemas/User のみを展開して出力
+jsonknife select --src my_schema.json --unwrap "#/components/schemas/User" -o user_schema.json
+
+# external.yaml の内容を、main.yaml の #/definitions/ExternalDef の位置に展開
+jsonknife select --src main.yaml --ref "external.yaml@#/definitions/ExternalDef" -o combined.yaml
+```
+`deref` サブコマンドは非推奨となり、`select` の使用が推奨されます。
+
+### `bundle`
+
+複数のファイルに分割されたJSON/YAMLドキュメント (特にOpenAPI/Swagger) を、JSON Referenceを解決しながら単一のファイルにまとめます。
+
+**主なオプション:**
+
+*   `--src <filepath_or_uri>`: メインとなる入力ファイルまたはURI。
+*   `--dst <filepath>`: 出力ファイル。省略すると標準出力。
+*   `--ref <JSON Pointer>`: `--src` ファイル内の特定のJSON Pointerを開始点としてバンドルします (例: `src.yaml#/components/schemas/User`)。
+*   `--flavor {openapiv3,openapiv2}`: OpenAPIのバージョン。デフォルトは `openapiv3`。ローカル参照のデフォルト位置 (`components/schemas` vs `definitions`) などに影響します。
+*   `--extra <filepath>` (複数指定可): バンドルプロセスに追加で読み込ませる外部ファイル。メインファイルから直接参照されていなくてもバンドルに含めたい定義などを指定できます。
+*   `-f, --format <fmt>`, `-i, --input-format <fmt>`, `-o, --output-format <fmt>`: フォーマット指定。
+
+**実行例:**
+
+```bash
+# main.yaml とそれが参照する ./schemas/*.yaml をバンドルして単一の openapi_bundled.yaml を作成
+jsonknife bundle --src main.yaml -o openapi_bundled.yaml
+
+# OpenAPI v2 形式でバンドル
+jsonknife bundle --src swagger.yaml --flavor openapiv2 -o swagger_bundled.yaml
+```
+
+### `separate`
+
+バンドルされた単一のJSON/YAMLドキュメントを、元のファイル構造 (`x-original-$ref`などの情報や参照パスに基づいて) に分割して複数のファイルとして出力します。
+
+**主なオプション:**
+
+*   `--src <filepath>`: バンドルされた入力ファイル。
+*   `--dst <directory_path>`: 分割されたファイルを出力するディレクトリ。省略するとカレントディレクトリ。
+*   `-f, --format <fmt>`, `-i, --input-format <fmt>`, `-o, --output-format <fmt>`: フォーマット指定。出力フォーマットは分割される各ファイルに適用されます。
+
+**実行例:**
+
+```bash
+# bundled_openapi.yaml を ./separated_components ディレクトリに分割
+jsonknife separate --src bundled_openapi.yaml --dst ./separated_components --output-format yaml
+```
+
+### `examples`
+
+OpenAPI/Swaggerスキーマからサンプル値を生成して出力します。
+
+**主なオプション:**
+
+*   `src <filepath_or_uri>`: 入力となるスキーマファイルまたはURI。
+*   `--dst <filepath>`: 出力ファイル。省略すると標準出力。
+*   `--ref <JSON Pointer>`: スキーマ内の特定の箇所 (例: `#/components/schemas/User`) からサンプル値を生成します。`src` に `#/foo` が含まれる場合はそれが優先されます。
+*   `--limit <int>`: 配列のサンプル値を生成する際の最大要素数。デフォルトは5。
+*   `--expand`: サンプル生成前に、入力スキーマの `$ref` をバンドル・展開します。複雑な参照を持つスキーマで有用です。
+*   `-f, --format <fmt>`, `-i, --input-format <fmt>`, `-o, --output-format <fmt>`: フォーマット指定。出力は通常JSON。
+
+**実行例:**
+
+```bash
+# api.yaml の User スキーマからサンプルJSONを生成
+jsonknife examples api.yaml --ref "#/components/schemas/User" -o user_example.json
+
+# 参照を解決してからサンプルを生成
+jsonknife examples api_with_refs.yaml --expand --ref "#/components/schemas/ComplexObject"
+```
+```

--- a/docs/apidoc/commands_swaggerknife.md
+++ b/docs/apidoc/commands_swaggerknife.md
@@ -1,0 +1,101 @@
+```markdown
+# `swaggerknife` コマンド
+
+`swaggerknife` コマンドラインツールは、Swagger/OpenAPIドキュメントに特化した高度な操作 (スキーマ変換、マージ、JSONからのスキーマ生成など) を提供します。
+
+## グローバルオプション
+
+*   `--log {DEBUG,INFO,WARNING,ERROR,CRITICAL}`: ログレベル。
+*   `-q, --quiet`: 警告抑制。
+*   `--debug`: デバッグモード。
+
+## サブコマンド
+
+### `tojsonschema`
+
+Swagger/OpenAPIドキュメントから特定の定義 (通常は `definitions` または `components/schemas` 内のスキーマ) を抽出し、単一のJSON Schemaファイルとして出力します。
+
+**主なオプション:**
+
+*   `--src <filepath>`: 入力Swagger/OpenAPIファイル。
+*   `--dst <filepath>`: 出力JSON Schemaファイル。省略すると標準出力。
+*   `--name <definition_name>`: 抽出する定義名 (例: `User`)。この名前のスキーマがルート要素となります。デフォルトは `top`。
+
+**実行例:**
+
+```bash
+# openapi.yaml の "User" 定義を user_schema.json として抽出
+swaggerknife tojsonschema --src openapi.yaml --name User --dst user_schema.json
+```
+
+### `json2swagger`
+
+1つまたは複数のJSONデータファイル (サンプルデータ) から、Swagger/OpenAPIのスキーマ定義 (`definitions` や `components/schemas` に配置される形式) を推測し、生成します。
+
+**主なオプション:**
+
+*   `files`: 入力JSONファイル名のリスト。
+*   `--dst <filepath>`: 出力Swagger/OpenAPIファイル。省略すると標準出力。
+*   `-o, --output-format <fmt>`: 出力フォーマット (例: `yaml`, `json`)。
+*   `--name <schema_name>`: 生成されるメインスキーマ (ルートオブジェクト) の名前。デフォルトは `top`。
+*   `--detector <class_name>`: スキーマ構造を検出するためのクラス名。デフォルトは `Detector` (`dictknife.swaggerknife.json2swagger.Detector`)。
+*   `--emitter <class_name>`: 検出された情報からスキーマを出力するためのクラス名。デフォルトは `Emitter` (`dictknife.swaggerknife.json2swagger.Emitter`)。
+*   `--annotate <filepath>`: スキーマ生成時に追加の情報を付与するためのアノテーションファイル (JSON/YAML形式)。特定のパスに対して型や説明などを手動で指定できます。
+*   `--emit {schema,info}`: `schema` (デフォルト) ならSwaggerスキーマを、`info` なら検出された中間情報 (デバッグ用) を出力します。
+*   `--with-minimap`: 生成されたスキーマの構造の概要をコメントとして出力します。
+*   `--without-example`: 生成されるスキーマから `example` フィールドを除去します。
+
+**実行例:**
+
+```bash
+# user_data.json と product_data.json からスキーマを推測し、api_definitions.yaml を生成
+swaggerknife json2swagger user_data.json product_data.json --name MainApi --dst api_definitions.yaml -o yaml
+
+# アノテーションファイルを使って詳細情報を追加
+swaggerknife json2swagger data.json --annotate annotations.yaml --dst schema_with_details.json
+```
+
+### `merge`
+
+複数のSwagger/OpenAPIファイルをマージします。
+
+**主なオプション:**
+
+*   `files`: 入力Swagger/OpenAPIファイル名のリスト。
+*   `--dst <filepath>`: 出力ファイル。省略すると標準出力。
+*   `--style {ref,whole}`: マージ戦略。デフォルトは `ref`。
+    *   `ref`: 各ファイルの定義を `$ref` を使って参照する形でマージします。出力ファイルからの相対パスで参照が記述されます。重複する定義名はエラーになる可能性があります (`--strict`参照)。
+    *   `whole`: 全てのファイルをインライン展開して1つの大きなファイルにマージします (`dictknife.deepmerge` の `override=True` に近い挙動)。
+*   `--strict`: (`ref` スタイルの場合) マージ時に定義名 (例: `definitions/User`) が衝突した場合にエラーとします。
+*   `--wrap <schema_name>`: マージ結果の特定のセクション (デフォルトは `definitions`) の全要素を参照するラッパースキーマを、指定した名前で作成します。これは、マージされた複数のファイルを単一のエンドポイント定義から参照可能にする場合などに使えます。
+*   `--wrap-section <section_name>`: `--wrap` オプションが対象とするセクション名。デフォルトは `definitions` (OpenAPI v2)。v3の場合は `components/schemas` などを指定する必要があるかもしれません。
+
+**実行例:**
+
+```bash
+# definitions1.yaml と definitions2.yaml を参照形式でマージ
+swaggerknife merge definitions1.yaml definitions2.yaml --dst combined_definitions.yaml --style ref
+
+# 全ての .yaml ファイルをインライン展開してマージし、"AllDefinitions" というラッパーでまとめる
+swaggerknife merge *.yaml --style whole --wrap AllDefinitions --wrap-section components/schemas -o final_api.yaml
+```
+
+### `flatten`
+
+JSON Schema (特にSwagger/OpenAPIドキュメント内の `definitions` または `components/schemas`) のネストしたインライン定義を展開し、トップレベルの定義として「持ち上げ」てフラットな構造にします。元の場所には新しいトップレベル定義への `$ref` が残ります。
+
+**主なオプション:**
+
+*   `src`: 入力ファイル名。
+*   `--dst <filepath>`: 出力ファイル。省略すると標準出力。
+*   `-i, --input-format <fmt>`, `-o, --output-format <fmt>`, `-f, --format <fmt>`: フォーマット指定。
+
+この機能は `dictknife.jsonknife.lifting.Flattener` を利用して、`definitions` (またはそれに類する) セクション内の各スキーマを処理します。
+
+**実行例:**
+
+```bash
+# complex_schema.yaml 内の definitions をフラット化
+swaggerknife flatten complex_schema.yaml -o flattened_schema.yaml
+```
+```

--- a/docs/apidoc/deepequal.md
+++ b/docs/apidoc/deepequal.md
@@ -1,0 +1,57 @@
+```markdown
+# `dictknife.deepequal`
+
+このモジュールは、ネストされた辞書やリストが、要素の順序が異なっていても意味的に等しいかどうかを比較する機能を提供します。
+
+## `deepequal(d0, d1, normalize=False)`
+
+2つのデータ構造 `d0` と `d1` が深く等しいかどうかを `bool` で返します。
+
+*   `d0`, `d1`: 比較する辞書またはリスト。
+*   `normalize=False` (デフォルト):
+    *   `False` の場合: 要素の順序を含めて厳密に比較します。リスト内の要素の順序や、辞書のキーの順序 (Python 3.7+では挿入順) が異なれば `False` となります。
+    *   `True` の場合: 比較前に内部的に `sort_flexibly` を使ってデータを正規化 (ソート) します。これにより、リスト内の要素の順序や、辞書内のキーの順序が異なっていても、内容が同じであれば等しいと判定されます。
+
+**実行例:**
+
+```python
+from dictknife.deepequal import deepequal
+from dictknife.langhelpers import make_dict
+
+# normalize=False (デフォルト)
+dict1 = {"a": 1, "b": [2, 3]}
+dict2 = {"b": [2, 3], "a": 1} # キーの順序が異なる (OrderedDictではない場合)
+dict3 = {"a": 1, "b": [3, 2]} # リストの順序が異なる
+
+print(deepequal(dict1, dict1)) # True
+# Python 3.7+ の dict は挿入順を保持するため、キーの順序が異なると False になりうる
+# ただし、標準の == 演算子はキーの順序を無視するため、この例では True になることが多い
+# print(deepequal(dict1, dict2)) # True (dictの==の挙動による)
+print(deepequal(dict1, dict3)) # False (リストの順序が異なるため)
+
+# normalize=True
+list1 = [{"id": 1}, {"id": 2}]
+list2 = [{"id": 2}, {"id": 1}]
+print(deepequal(list1, list2, normalize=False)) # False
+print(deepequal(list1, list2, normalize=True))  # True
+
+schema1 = {"type": "string", "enum": ["A", "B", "C"]}
+schema2 = {"enum": ["C", "A", "B"], "type": "string"}
+print(deepequal(schema1, schema2, normalize=False)) # False (キー順序やenumの順序が異なる)
+print(deepequal(schema1, schema2, normalize=True))  # True
+```
+
+## `sort_flexibly(ob)`
+
+与えられたオブジェクト `ob` (辞書やリスト) を再帰的にソートし、正規化された表現を返します。`deepequal` で `normalize=True` の場合に内部的に使用されます。
+
+この関数は、リスト内の要素をその内容に基づいてソートし、辞書もキーでソートされたかのように扱います。これにより、順序が異なるだけで内容は同じデータ構造が、比較可能になります。
+
+通常、直接この関数を使用する必要はありません。
+
+## `halfequal(left, right)`
+
+`left` の全ての要素が `right` に存在し、かつそれらが再帰的に等しいかどうかを判定します。`deepequal` はこれを双方向で呼び出すことで等価性を担保しています ( `normalize=False` の場合)。
+
+通常、直接この関数を使用する必要はありません。
+```

--- a/docs/apidoc/deepmerge.md
+++ b/docs/apidoc/deepmerge.md
@@ -1,0 +1,114 @@
+```markdown
+# `dictknife.deepmerge`
+
+このモジュールは、複数の辞書やリストを深くマージする機能を提供します。マージの挙動は `method` オプションによって制御できます。
+
+## `deepmerge(*ds, override=False, method="addtoset")`
+
+可変長引数 `*ds` で与えられた複数の辞書 (またはリスト) を順番にマージし、新しいマージ済みのオブジェクトを返します。元のオブジェクトは変更されません。
+
+*   `*ds`: マージする辞書またはリスト。最初の要素がベースとなり、後続の要素が順にマージされます。
+*   `override=False` (非推奨): このオプションは非推奨です。`True` に設定すると `method="replace"` と同じ挙動になります。
+*   `method="addtoset"` (デフォルト): マージ戦略を指定します。以下のいずれかの文字列を指定できます。
+
+    *   `"addtoset"`:
+        *   **辞書の場合:** キーが重複する場合、値を再帰的に `deepmerge` (この場合は `addtoset` 戦略で) します。新しいキーは追加されます。
+        *   **リストの場合:** 右側のリストの要素を左側のリストに追加します。ただし、重複する要素は追加しません (集合的な追加)。要素の比較は `in` 演算子で行われます。
+    *   `"append"`:
+        *   **辞書の場合:** `"addtoset"` と同様です。
+        *   **リストの場合:** 右側のリストの要素を左側のリストに単純に追加します (重複を許容)。
+    *   `"merge"`:
+        *   **辞書の場合:** `"addtoset"` と同様です。
+    *   **リストの場合:** `itertools.zip_longest` を使用し、対応するインデックスの要素同士を再帰的に `deepmerge` (この場合は `"merge"` 戦略で) します。
+        *   要素がプリミティブ型の場合、右側の要素の値で左側の要素の値を置き換えます。
+        *   要素が辞書やリストの場合、さらに再帰的にマージされます。
+        *   リストの長さが異なる場合、長い方のリストの残りの要素がそのまま結果に含まれます。
+    *   `"replace"`:
+        *   **辞書の場合:** キーが重複する場合、右側の値で左側の値を完全に置き換えます (再帰的なマージは行いません)。
+        *   **リストの場合:** 右側のリストで左側のリストを完全に置き換えます。
+
+**実行例:**
+
+```python
+from dictknife.deepmerge import deepmerge
+from dictknife.langhelpers import make_dict # 通常 OrderedDict
+
+d1 = make_dict({"name": "app", "version": "1.0", "settings": {"debug": True, "port": 8000}, "tags": ["web", "api"]})
+d2 = make_dict({"version": "1.1", "settings": {"port": 8080, "timeout": 30}, "tags": ["api", "v1"], "new_prop": "hello"})
+
+# method="addtoset" (デフォルト)
+merged_addtoset = deepmerge(d1, d2)
+# print(merged_addtoset)
+# {
+#   'name': 'app',
+#   'version': '1.1',
+#   'settings': {'debug': True, 'port': 8080, 'timeout': 30},
+#   'tags': ['web', 'api', 'v1'], # 'api'は重複しない
+#   'new_prop': 'hello'
+# }
+
+# method="append"
+merged_append = deepmerge(d1, d2, method="append")
+# print(merged_append)
+# {
+#   'name': 'app',
+#   'version': '1.1',
+#   'settings': {'debug': True, 'port': 8080, 'timeout': 30},
+#   'tags': ['web', 'api', 'api', 'v1'], # 'api'が重複して追加される
+#   'new_prop': 'hello'
+# }
+
+# method="replace"
+merged_replace = deepmerge(d1, d2, method="replace")
+# print(merged_replace)
+# {
+#   'name': 'app',
+#   'version': '1.1',
+#   'settings': {'port': 8080, 'timeout': 30}, # settings全体がd2のもので置き換え
+#   'tags': ['api', 'v1'], # tags全体がd2のもので置き換え
+#   'new_prop': 'hello'
+# }
+
+
+# "merge" メソッドのリストの挙動
+list1 = make_dict({"items": [make_dict({"id":1, "val": "a"}), make_dict({"id":2, "val":"b"})]})
+list2 = make_dict({"items": [make_dict({"val": "x"}), make_dict({"id":3, "val":"y"}), make_dict({"id":4, "val":"z"})]})
+
+merged_list_merge = deepmerge(list1, list2, method="merge")
+# print(merged_list_merge)
+# {
+#  'items': [
+#    {'id': 1, 'val': 'x'}, # id:1, val:a と val:x がマージ (プリミティブは上書き)
+#    {'id': 3, 'val': 'y'}, # id:2, val:b と id:3, val:y がマージ (キーがなければ追加、あれば上書き)
+#    {'id': 4, 'val': 'z'}  # d2の3番目の要素がそのまま追加
+#  ]
+# }
+
+# "merge" メソッドのリストの挙動 (プリミティブ要素)
+list_prim1 = make_dict({"values": [10, 20, 30]})
+list_prim2 = make_dict({"values": [15, 25]})
+merged_list_prim = deepmerge(list_prim1, list_prim2, method="merge")
+# print(merged_list_prim)
+# {
+#   'values': [15, 25, 30] # 10->15, 20->25, 30はそのまま
+# }
+
+# 複数の辞書をマージ
+d3 = make_dict({"settings": {"user": "admin"}, "tags": ["stable"]})
+merged_multiple = deepmerge(d1, d2, d3, method="addtoset")
+# print(merged_multiple)
+# {
+#   'name': 'app',
+#   'version': '1.1',
+#   'settings': {'debug': True, 'port': 8080, 'timeout': 30, 'user': 'admin'},
+#   'tags': ['web', 'api', 'v1', 'stable'],
+#   'new_prop': 'hello'
+# }
+```
+
+**注意点:**
+
+*   `deepmerge` は新しい辞書/リストを返します。元のオブジェクトは変更されません。
+*   `make_dict` はデフォルトで `dictknife.langhelpers.make_dict` を使用するため、結果の辞書はキーの挿入順を保持する傾向があります (Python 3.7+ の `dict` または `OrderedDict`)。
+*   リスト内の要素が辞書の場合、その辞書のマージも指定された `method` に従って再帰的に行われます (ただし、リスト自体が `"replace"` される場合を除く)。
+```

--- a/docs/apidoc/diff.md
+++ b/docs/apidoc/diff.md
@@ -1,0 +1,118 @@
+```markdown
+# `dictknife.diff`
+
+このパッケージは、2つの辞書やリストの差分を計算し、様々な形式で表示する機能を提供します。
+
+## `diff.py` - Unified Diff形式
+
+### `diff(d0, d1, tostring=None, fromfile="left", tofile="right", n=3, terminator="\n", normalize=False, sort_keys=False)`
+
+2つのデータ構造 `d0` と `d1` の差分を `unified_diff` 形式 (一般的な `diff -u` のような出力) の行イテレータとして返します。
+
+*   `d0`, `d1`: 比較するデータ構造 (辞書、リストなど)。イテレータも可。
+*   `tostring=None`: データ構造を文字列に変換する関数。
+    *   デフォルト (`None`) の場合、内部で `json.dumps(d, indent=2, ensure_ascii=False, sort_keys=sort_keys, default=str)` を使用して整形されたJSON文字列に変換します。
+*   `fromfile="left"`, `tofile="right"`: diff出力のヘッダーに表示されるファイル名。
+*   `n=3`: 変更箇所の前後何行のコンテキストを表示するか。
+*   `terminator="\n"`: `tostring` で変換された文字列を行に分割する際の区切り文字。
+*   `normalize=False`:
+    *   `True` の場合、比較前に `dictknife.deepequal.sort_flexibly` を使ってデータを正規化します。これは主にリスト内の要素の順序や辞書のキーの順序が異なる場合に意味のある差分を得るために使われます。
+    *   **重要:** `normalize=True` の場合、`sort_flexibly` の処理の一環として、全てのデータ値が `dictknife.transform.str_dict` によって文字列に変換された上で比較されます。そのため、数値やブール値なども文字列として比較される点に注意が必要です。これにより、例えば `1` と `"1"` が異なるものとして扱われる可能性があります (ただし、`sort_flexibly` がこれらを同一視するような正規化を行う場合を除く)。
+*   `sort_keys=False`: `tostring` がデフォルトのJSON変換の場合に、JSONのキーをソートするかどうか。`normalize=True` の場合は、`sort_flexibly` によるソートが優先されるため、このオプションの影響は限定的です。
+
+**実行例:**
+
+```python
+from dictknife.diff import diff
+import datetime
+
+d0 = {"x": datetime.date(2000, 1, 1), "y": {"a": 1, "b": 10}, "z": [1,2,3]}
+d1 = {"x": datetime.date(2000, 2, 1), "y": {"a": 1, "c": 10}, "z": [1,3,4]}
+
+for line in diff(d0, d1, fromfile="old.json", tofile="new.json"):
+    print(line)
+
+# 出力例:
+# --- old.json
+# +++ new.json
+# @@ -1,10 +1,10 @@
+#  {
+# -  "x": "2000-01-01",
+# -  "y": {
+# -    "a": 1,
+# -    "b": 10
+# -  },
+# -  "z": [
+# -    1,
+# -    2,
+# -    3
+# -  ]
+# +  "x": "2000-02-01",
+# +  "y": {
+# +    "a": 1,
+# +    "c": 10
+# +  },
+# +  "z": [
+# +    1,
+# +    3,
+# +    4
+# +  ]
+#  }
+```
+
+## `rows.py` - 行ベースの差分表現
+
+### `diff_rows(d0, d1, *, fromfile="left", tofile="right", diff_key="diff", normalize=False)`
+
+2つのデータ構造 `d0` と `d1` の差分を、各要素（プリミティブ値）ごとに行として表現した辞書のリストで返します。これはプログラムで差分を処理しやすい形式です。
+
+*   `d0`, `d1`: 比較するデータ構造。
+*   `fromfile="left"`, `tofile="right"`: 結果の辞書内で、`d0` の値と `d1` の値を指すキー名。
+*   `diff_key="diff"`: 結果の辞書内で、差分の内容を指すキー名。
+*   `normalize=False`: `diff` 関数と同様に、比較前にデータを正規化します。
+
+各行の辞書は以下のキーを持ちます:
+*   `"name"`: 要素へのJSON Pointer風のパス (例: `"key1/0/key2"`)。
+*   `fromfile` キー (デフォルト `"left"`): `d0` における値。
+*   `tofile` キー (デフォルト `"right"`): `d1` における値。
+*   `diff_key` キー (デフォルト `"diff"`): 差分の内容。
+    *   数値の場合: `d1 - d0` の値。
+    *   文字列の場合: `difflib.ndiff` による差分文字列 (例: `"- f- o- o+ b+ a+ r"`)。
+    *   変更がない場合: 数値なら `0`、文字列なら空文字列 `""`。
+    *   片方にしか存在しない場合: `None`。
+
+**実行例:**
+
+```python
+from dictknife.diff.rows import diff_rows
+from collections import OrderedDict
+
+left = OrderedDict([
+    ("x", 10),
+    ("y", "hello"),
+    ("nested", OrderedDict([("z", True)])),
+    ("items", [10, 20, "apple"])
+])
+right = OrderedDict([
+    ("x", 15),
+    ("y", "world"),
+    ("nested", OrderedDict([("z", False), ("new", 100)])),
+    ("items", [10, 25, "orange"])
+])
+
+rows = diff_rows(left, right)
+for row in rows:
+    print(row)
+
+# 出力例:
+# {'name': 'x', 'left': 10, 'right': 15, 'diff': 5}
+# {'name': 'y', 'left': 'hello', 'right': 'world', 'diff': '- h- e- l- l- o+ w+ o+ r+ l+ d'} # 文字列差分
+# {'name': 'nested/z', 'left': True, 'right': False, 'diff': '- T- r- u- e+ F+ a+ l+ s+ e'} # 真偽値も文字列として比較される
+# {'name': 'nested/new', 'left': None, 'right': 100, 'diff': None} # 片方のみ存在
+# {'name': 'items/0', 'left': 10, 'right': 10, 'diff': 0} # 数値変更なし
+# {'name': 'items/1', 'left': 20, 'right': 25, 'diff': 5} # 数値変更あり
+# {'name': 'items/2', 'left': 'apple', 'right': 'orange', 'diff': '- a- p- p- l- e+ o+ r+ a+ n+ g+ e'} # 文字列変更
+```
+
+`dictknife diff` コマンドの `--output-format` オプションで `dict`, `md`, `tsv` などを指定した場合、この `diff_rows` の結果が利用されていると考えられます。
+```

--- a/docs/apidoc/guessing.md
+++ b/docs/apidoc/guessing.md
@@ -1,0 +1,95 @@
+```markdown
+# `dictknife.guessing`
+
+このモジュールは、文字列として表現されたデータ (特に辞書やリストの要素) を、その内容に基づいて適切なPythonの型（真偽値、整数、浮動小数点数など）に自動的に変換（推測）する機能を提供します。
+
+CSVファイルや環境変数から読み込んだデータのように、全ての値が最初は文字列として扱われている場合に、それらを構造化データとして扱う前処理として便利です。
+
+## `guess(d, *, guesser_factory=Guesser, default=None, mutable=False)`
+
+メインのインターフェース関数です。与えられたデータ構造 `d` (辞書やリスト) 内の文字列値を再帰的にスキャンし、型推測と変換を試みます。
+
+*   `d`: 型推測を行いたいデータ構造 (辞書やリスト)。
+*   `guesser_factory=Guesser`: `Guesser` クラス (または互換性のあるクラス) を指定します。通常は変更する必要はありません。
+*   `default=None`: `Guesser` に渡される `default` 関数を指定します。これは、どの型 (bool, int, float) にも一致しない文字列をどのように処理するかを定義します。デフォルトでは、文字列をそのまま返します。
+*   `mutable=False` (デフォルト):
+    *   `False` の場合: 非破壊的な変換を行います。つまり、元のデータ構造は変更されず、変換後の新しいオブジェクトが返されます。
+    *   `True` の場合: 元のデータ構造を直接変更します (破壊的変換)。
+
+**変換ルール:**
+
+1.  入力値がリストや辞書の場合、その要素に対して再帰的に `guess` を呼び出します。
+2.  入力値が文字列でない場合、そのまま返します。
+3.  入力値が文字列の場合、以下の順で型を推測し、一致すれば対応するPythonの型に変換します:
+    *   **真偽値:** `"true"`, `"True"`, `"false"`, `"False"` など (大文字・小文字を区別しない) は `bool` (`True`, `False`) に変換されます。
+    *   **整数:** `"-?[1-9]\d*"` または `"0"` に一致する文字列 (例: `"123"`, `"-45"`, `"0"`) は `int` に変換されます。
+    *   **浮動小数点数:** `"-?(?:\d*\.\d+(?:e-\d+)?|nan|inf)"` に一致する文字列 (例: `"3.14"`, `".5"`, `"1e-5"`, `"NaN"`, `"Infinity"`, `"-Infinity"`) は `float` に変換されます。`"nan"`, `"inf"` の大文字・小文字は区別される可能性があります (実装依存ですが、多くの場合 `float('nan')`, `float('inf')` になります)。
+    *   上記のいずれにも一致しない場合、`default` 関数 (指定されていれば) の結果、または元の文字列がそのまま返されます。
+
+**実行例:**
+
+```python
+from dictknife.guessing import guess
+
+data_str = {
+    "name": "item",
+    "count": "100",
+    "price": "25.50",
+    "available": "True",
+    "discount_rate": "0.1",
+    "metadata": {
+        "id_str": "007",
+        "negative_int": "-5",
+        "is_active": "false",
+        "not_a_number": "text",
+        "infinity_val": "inf",
+        "nan_val": "NaN"
+    },
+    "tags": ["tag1", "123", "False", "0.5"] # リスト内の型変換可能な文字列も対象
+}
+
+# 非破壊的変換 (デフォルト)
+guessed_data = guess(data_str)
+# print(guessed_data)
+# {
+#   'name': 'item',
+#   'count': 100,
+#   'price': 25.5,
+#   'available': True,
+#   'discount_rate': 0.1,
+#   'metadata': {
+#     'id_str': 7,
+#     'negative_int': -5,
+#     'is_active': False,
+#     'not_a_number': 'text'
+#   },
+#   'tags': ['tag1', 123, False]
+# }
+
+# 元のデータは変更されていない
+# print(data_str["count"]) # "100" (文字列のまま)
+
+# 破壊的変換
+data_to_mutate = {
+    "value_int": "42",
+    "value_float": "3.14",
+    "value_bool": "false"
+}
+guess(data_to_mutate, mutable=True)
+# print(data_to_mutate)
+# {
+#   'value_int': 42,
+#   'value_float': 3.14,
+#   'value_bool': False
+# }
+# data_to_mutate["value_int"] は 42 (int) に変更されている
+```
+
+## `Guesser` クラス
+
+`guess` 関数が内部で使用するクラスです。型判定のための正規表現や再帰的な処理ロジックをカプセル化しています。通常、ユーザーが直接このクラスをインスタンス化する必要はありません。
+
+主なメソッド:
+*   `is_bool(self, v)`, `is_int(self, v)`, `is_float(self, v)`: 文字列 `v` がそれぞれの型にマッチするかどうかを判定します。
+*   `guess(self, v)`: 実際の型推測と変換ロジック。
+```

--- a/docs/apidoc/jsonknife_modules.md
+++ b/docs/apidoc/jsonknife_modules.md
@@ -1,0 +1,98 @@
+```markdown
+# `dictknife.jsonknife` (サブモジュール群)
+
+`dictknife.jsonknife` パッケージは、JSON (および互換フォーマット) ドキュメント、特にJSON Reference (`$ref`) を多用するOpenAPI/Swaggerのようなスキーマファイルを扱うためのコア機能を提供するサブモジュール群を含んでいます。`jsonknife` コマンドラインツールはこれらのモジュールを利用しています。
+
+## `accessor.py` - JSON Pointerと参照アクセス
+
+JSON Pointer (RFC6901) を使ったドキュメント内要素へのアクセス、割り当て、削除や、JSON Referenceの解決と連携するアクセサを提供します。
+
+*   **`access_by_json_pointer(doc, query, *, guess=False)`**: `doc` 内の `query` (JSON Pointer) で指定された要素を取得。`guess=True` で数値風文字列キーを整数インデックスとしてフォールバック。
+*   **`assign_by_json_pointer(doc, query, value, *, guess=False)`**: `doc` 内の `query` に `value` を割り当て。
+*   **`maybe_remove_by_json_pointer(doc, query)`**: `doc` 内の `query` の要素を削除。
+*   **`path_to_json_pointer(path_list)`**: キー/インデックスのリストをJSON Pointer文字列に変換。
+*   **`json_pointer_to_path(json_pointer_str)`**: JSON Pointer文字列をキー/インデックスのリストに変換。
+*   **`StackedAccessor`**: `Resolver` のスタックを管理し、相対的な `$ref` を解決しながらデータにアクセス。
+*   **`CachedItemAccessor(StackedAccessor)`**: 解決した `$ref` の結果 (ファイルとデータ) をキャッシュし、再アクセスを高速化。
+
+## `resolver.py` - JSON Referenceの解決
+
+`$ref` (ローカルおよび外部ファイル) を解決し、参照先のデータを取得するリゾルバ。
+
+*   **`OneDocResolver`**: 単一ドキュメント内でのみ `$ref` を解決。外部参照不可。
+*   **`ExternalFileResolver`**: 外部ファイルへの `$ref` を解決可能。
+    *   ファイルの読み込みとキャッシュ (同じファイルは再読込しない)。
+    *   相対パス (`../common.yaml#/definitions/Error`) や絶対パスの参照を解決。
+    *   `onload` コールバックでロード後の処理をフック可能。
+*   **`get_resolver(filename_or_none, ...)`**: `filename` の有無に応じて適切なリゾルバを返すファクトリ。
+*   **`build_subset(resolver, ref_pointer)`**: 指定ポインタから参照される全要素を含む部分ドキュメントを構築。
+
+## `expander.py` - JSON Referenceの展開 (Dereference)
+
+`Resolver` を使用してドキュメント内の `$ref` を再帰的に展開 (インライン化) します。
+
+*   **`Expander` クラス**:
+    *   `__init__(resolver)`: `Resolver` インスタンスを取る。
+    *   `expand()`: リゾルバのルートドキュメント全体を展開。
+    *   `expand_subpart(subpart_data)`: データの一部を展開。
+    *   循環参照を検出し、無限ループを防ぐために展開しないようにします (元の `$ref` を残す)。
+
+## `bundler.py` - 分割ドキュメントのバンドル
+
+複数のファイルに分割されたドキュメント群を、`$ref` を解決・正規化しながら単一のドキュメントにまとめます。
+
+*   **`Bundler` クラス**:
+    *   `__init__(resolver, strict=False, scanner_factory=None)`
+    *   `bundle()`: メイン処理。
+        1.  `Scanner` が全参照をスキャンし、外部定義を `item_map` に収集。ローカル参照パスも正規化 (例: `#/definitions/Foo` や `#/components/schemas/Foo`)。
+        2.  `LocalrefFixer` がローカル参照名の衝突を回避 (例: ファイル名ベースのプレフィックス付加)。
+        3.  `Emitter` が収集・正規化された定義群を単一ドキュメント内に再配置し、全ての `$ref` をバンドル後のローカル参照に書き換える。
+*   **`create_scanner_factory_from_flavor(flavor)`**: OpenAPI v2/v3 に応じた `Scanner` 設定を返します。
+
+## `separator.py` - バンドル済みドキュメントの分割
+
+バンドルされた単一ドキュメントを、元のファイル構造や `$ref` パスに基づいて複数のファイルに分割します。
+
+*   **`Separator` クラス**:
+    *   `__init__(resolver, format=None, here=None)`
+    *   `separate()`: メイン処理。
+        1.  `Scanner` がドキュメント内のローカル参照 (`#/definitions/Foo` など) を基に、分割可能な定義とその出力先ファイルパスを特定。
+        2.  `Emitter` が特定された各定義を個別のファイルとして書き出し。その際、ファイル内の `$ref` は新しいファイルからの相対パスに修正。
+        3.  メインファイルも更新され、分割された定義への `$ref` が新しいファイルパスを指すように変更される。「ツリーシェイキング」により、どこからも参照されなくなった定義はメインファイルから削除されることがある。
+
+## `lifting.py` - スキーマ定義の持ち上げ
+
+ネストしたインラインスキーマ定義 (オブジェクトや配列のアイテム) をトップレベルの `definitions` (または同様のセクション) に「持ち上げ」、元の場所にはそれへの `$ref` を残します。
+
+*   **`Flattener` クラス**:
+    *   `extract(schema_data, handler_context)`: スキーマデータを再帰的に処理。
+    *   ネストしたオブジェクトや配列の `items` が匿名定義の場合、`Handler` が生成する名前 (例: `ParentNamePropertyName`, `ArrayNameItem`) でトップレベルに抽出し、元の場所を `$ref` で置き換える。
+*   **`Handler` クラス**: 処理中のコンテキスト (現在のパス、持ち上げた定義を格納する辞書) を管理。
+
+## `merge.py` - JSON Merge Patch (RFC 7396)
+
+RFC 7396 (JSON Merge Patch) の仕様に基づいて2つのドキュメントをマージします。
+
+*   **`merge(target_doc, patch_doc)`**:
+    *   `patch_doc` の値が `null` の場合、`target_doc` から対応するキーを削除。
+    *   `patch_doc` の値がオブジェクトの場合、再帰的にマージ。
+    *   それ以外の場合 (文字列、数値、配列、`true`, `false`)、`target_doc` の対応する値を `patch_doc` の値で完全に置き換える (配列は要素ごとではなく全体が置換)。
+
+## `patch.py` - JSON Patch (RFC 6902) の生成
+
+2つのドキュメントを比較し、最初のドキュメントを2番目のドキュメントに変換するためのJSON Patch操作 (RFC 6902) のシーケンスを生成します。
+
+*   **`make_jsonpatch(src_doc, dst_doc, *, verbose=False)`**:
+    *   `src_doc` から `dst_doc` への変更点を `add`, `remove`, `replace` (現在は `copy`, `move`, `test` は直接生成しない) 操作としてリストで返す。
+    *   `verbose=True` で追加のデバッグ情報 (`x-from` など) を付加。
+    *   内部で `_Walker` が再帰的に差分を検出し、`_merge` がパスを付加して整形。
+
+## `relpath.py` - 相対パス操作ユーティリティ
+
+ファイルパスや `$ref` 文字列内の相対パスを、基準パスや移動先パスに応じて解決・変換します。
+
+*   **`fixpath(relpath, *, where, to)`**: `where` からの相対パス `relpath` が指す実体を、`to` からの相対パスに変換。
+*   **`fixref(ref_str, *, where, to)`**: `$ref` 文字列内のファイルパス部分を `fixpath` で変換。
+*   **`relpath(fpath_in_ref, *, where)`**: `$ref` 内のファイルパス `fpath_in_ref` を `where` からの絶対パスに変換。
+*   **`normpath(relpath, *, where)`**: `where` からの相対パス `relpath` を正規化された絶対パスに変換。
+```

--- a/docs/apidoc/langhelpers.md
+++ b/docs/apidoc/langhelpers.md
@@ -1,0 +1,156 @@
+```markdown
+# `dictknife.langhelpers`
+
+このモジュールは、`dictknife` ライブラリ全体で利用される可能性のある、さまざまな補助関数やクラスを提供します。文字列操作、プロパティのキャッシュ、JSON Pointerの変換などが含まれます。
+
+## `make_dict`
+
+Pythonのバージョンに応じて、`dict` (Python 3.6以降) または `collections.OrderedDict` (それ以前) を返します。これは、辞書のキーの順序を保持するための互換性レイヤーとして機能します。
+
+**利用例:**
+
+```python
+from dictknife.langhelpers import make_dict
+
+# Python 3.6 以降では通常の dict と同様
+my_dict = make_dict()
+my_dict["b"] = 1
+my_dict["a"] = 2
+print(list(my_dict.keys())) # 環境により ['b', 'a'] または ['a', 'b'] (3.7+なら挿入順)
+
+# Python 3.5 以前では OrderedDict と同様
+# (OrderedDict の場合、キーは挿入順に保持される)
+```
+*注: この `make_dict` は `dictknife.accessing.Accessor` など、他のモジュールでデフォルトの辞書ファクトリとして内部的に利用されることがあります。*
+
+## `pairsplit(s, sep)`
+
+文字列 `s` を、最初の区切り文字 `sep` で2つの部分に分割します。区切り文字が見つからない場合、2つ目の要素は空文字列になります。
+
+*   `s`: 分割する文字列。
+*   `sep`: 区切り文字。
+
+**戻り値:** `(文字列1, 文字列2)` のタプル。
+
+**実行例:**
+
+```python
+from dictknife.langhelpers import pairsplit
+
+result1 = pairsplit("key=value", "=")
+# result1 is ('key', 'value')
+
+result2 = pairsplit("key:value:another", ":")
+# result2 is ('key', 'value:another')
+
+result3 = pairsplit("keyonly", "=")
+# result3 is ('keyonly', '')
+```
+
+## `pairrsplit(s, sep)`
+
+文字列 `s` を、最後の区切り文字 `sep` で2つの部分に分割します。区切り文字が見つからない場合、2つ目の要素は空文字列になります。`rsplit` の動作に似ています。
+
+*   `s`: 分割する文字列。
+*   `sep`: 区切り文字。
+
+**戻り値:** `(文字列1, 文字列2)` のタプル。
+
+**実行例:**
+
+```python
+from dictknife.langhelpers import pairrsplit
+
+result1 = pairrsplit("key=value=another", "=")
+# result1 is ('key=value', 'another')
+
+result2 = pairrsplit("one:two", ":")
+# result2 is ('one', 'two')
+
+result3 = pairrsplit("keyonly", "=")
+# result3 is ('keyonly', '')
+```
+
+## `reify` クラス
+
+プロパティをキャッシュするためのデコレータクラスです。一度計算されたプロパティの値はインスタンスに保存され、次回以降のアクセスでは再計算せずに保存された値を返します。
+これは [pyramid](https://trypyramid.com/) フレームワークから着想を得たものです。
+
+**利用例:**
+
+```python
+from dictknife.langhelpers import reify
+
+class MyClass:
+    def __init__(self, data):
+        self._data = data
+        self._compute_count = 0
+
+    @reify
+    def expensive_property(self):
+        print("Computing expensive_property...")
+        self._compute_count += 1
+        # 何か重い計算をシミュレート
+        return sum(self._data)
+
+obj = MyClass([1, 2, 3, 4, 5])
+
+print(obj.expensive_property)  # "Computing expensive_property..." が出力され、15 が表示される
+print(f"Compute count: {obj._compute_count}") # 1
+
+print(obj.expensive_property)  # 計算は行われず、キャッシュされた 15 が表示される
+print(f"Compute count: {obj._compute_count}") # 1 (増えない)
+
+# プロパティはインスタンスの属性として保存される
+print(obj.__dict__["expensive_property"]) # 15
+```
+
+## `as_jsonpointer(k)`
+
+与えられたキー `k` (通常は文字列または整数) をJSON Pointerのフラグメント識別子形式に変換します。具体的には、`~` を `~0` に、`/` を `~1` にエスケープします。
+
+*   `k`: 変換するキー。文字列に変換されて処理されます。
+
+**戻り値:** JSON Pointer形式の文字列。
+
+**実行例:**
+
+```python
+from dictknife.langhelpers import as_jsonpointer
+
+ptr1 = as_jsonpointer("foo")
+# ptr1 is "foo"
+
+ptr2 = as_jsonpointer("foo/bar")
+# ptr2 is "foo~1bar"
+
+ptr3 = as_jsonpointer("foo~bar")
+# ptr3 is "foo~0bar"
+
+ptr4 = as_jsonpointer(0) # 数値も扱える
+# ptr4 is "0"
+```
+
+## `as_path_node(ref)`
+
+JSON Pointerのフラグメント識別子形式の文字列 `ref` を、元のキーの形式に戻します。`as_jsonpointer` の逆操作に相当し、`~1` を `/` に、`~0` を `~` にアンエスケープします。
+
+*   `ref`: JSON Pointer形式の文字列。
+
+**戻り値:** 元のキー形式の文字列。
+
+**実行例:**
+
+```python
+from dictknife.langhelpers import as_path_node
+
+node1 = as_path_node("foo")
+# node1 is "foo"
+
+node2 = as_path_node("foo~1bar")
+# node2 is "foo/bar"
+
+node3 = as_path_node("foo~0bar")
+# node3 is "foo~bar"
+```
+```

--- a/docs/apidoc/loading.md
+++ b/docs/apidoc/loading.md
@@ -1,0 +1,110 @@
+```markdown
+# `dictknife.loading`
+
+`dictknife.loading` パッケージは、様々なデータフォーマットの読み込み (load) と書き出し (dump) を行うための統一的なフレームワークを提供します。これにより、`dictknife` の各ツールはファイル形式を意識することなく、構造化データを透過的に扱うことができます。
+
+## 主要なコンセプト
+
+*   **`Dispatcher`**: 中心的な役割を担い、ファイル拡張子や指定されたフォーマット名に基づいて、適切なロード/ダンプ関数を割り当てます。グローバルインスタンス `dictknife.loading.dispatcher` が存在します。
+*   **`Loader`**: `dispatcher` の一部として機能し、データの読み込み処理を担当します。
+*   **`Dumper`**: `dispatcher` の一部として機能し、データの書き出し処理を担当します。
+*   **フォーマット固有モジュール**: `json.py`, `yaml.py`, `csv.py` など、各フォーマットに対応する実際の読み書きロジックを実装したモジュール群。これらは通常、対応するPythonライブラリ (例: `json`, `ruamel.yaml`, `tomlkit`, `csv`) をラップします。
+
+## 提供される関数 (ショートカット)
+
+`dictknife.loading` モジュールから直接インポートして使用できる主要な関数です。これらは内部でグローバルな `dispatcher` を利用します。
+
+*   **`load(fp, format=None, errors=None)`**:
+    ファイルポインタ `fp` からデータをロードします。
+    *   `format`: フォーマットを明示的に指定 (例: `"json"`, `"yaml"`)。省略時は `fp.name` (ファイル名) の拡張子から推測されます。
+    *   `errors`: (主にCSVなどで) パースエラー時の処理方法。
+*   **`loads(s, format=None, ...)`**:
+    文字列 `s` からデータをロードします。内部で `StringIO(s)` を `load()` に渡します。
+*   **`loadfile(filename=None, format=None, opener=None, encoding=None, errors=None)`**:
+    ファイル名 `filename` からデータをロードします。`filename` が `None` または `sys.stdin` の場合は標準入力から読み込みます。
+    *   `opener`: 特殊なファイルオープン処理が必要な場合に指定 (例: Google Spreadsheet)。
+    *   `encoding`: ファイルのエンコーディング。
+*   **`dump(d, fp, *, format=None, sort_keys=False, extra=None)`**:
+    データ `d` をファイルポインタ `fp` に指定されたフォーマットで書き出します。
+    *   `format`: 出力フォーマット。省略時は `fp.name` から推測。
+    *   `sort_keys=False`: (主にJSON, YAMLで) キーをソートするかどうか。
+    *   `extra=None`: フォーマット固有の追加オプションを辞書で渡します。
+*   **`dumps(d, *, format=None, sort_keys=False, extra=None, **kwargs)`**:
+    データ `d` を指定されたフォーマットの文字列として返します。
+*   **`dumpfile(d, filename=None, *, format=None, sort_keys=False, extra=None)`**:
+    データ `d` をファイル名 `filename` に書き出します。`filename` が `None` または `sys.stdout` の場合は標準出力に書き出します。ファイル書き出し時に親ディレクトリが存在しなければ作成します。
+*   **`guess_format(filename, *, default=unknown)`**:
+    ファイル名からフォーマットを推測します。
+*   **`get_opener(*, format=None, filename=None, default=open)`**:
+    フォーマットやファイル名に適したファイルオープナー関数を取得します。
+*   **`get_formats()`**:
+    現在登録されている利用可能なフォーマット名のリストを返します。
+*   **`setup(input=None, output=None)`**:
+    ファイル拡張子からフォーマットが推測できない場合のデフォルトの入力/出力処理関数 (通常は `yaml.load`/`yaml.dump`) を上書きします。
+
+## 対応フォーマットと関連モジュール
+
+`dictknife.loading.dispatcher` には、以下のフォーマットがデフォルトで登録されています。
+
+| フォーマット名 | 拡張子 (例)           | 依存ライブラリ (主なもの) | ロードモジュール/関数                                  | ダンプモジュール/関数                                   | 備考                                                                             |
+|----------------|-----------------------|---------------------------|------------------------------------------------------|-------------------------------------------------------|----------------------------------------------------------------------------------|
+| `json`         | `.json`, `.js`        | (標準 `json`)             | `json.load` (標準 `json` + `OrderedDict`)            | `json.dump` (標準 `json`, indent=2, ensure_ascii=False) | キーの順序は保持される傾向。                                                           |
+| `yaml`         | `.yaml`, `.yml`       | `ruamel.yaml`             | `yaml.load` (`ruamel.yaml` round-trip)               | `yaml.dump` (`ruamel.yaml` round-trip)                | コメントやスタイルを極力保持。エイリアスは出力しない。                                   |
+| `toml`         | `.toml`               | `tomlkit`                 | `toml.load` (`tomlkit`)                              | `toml.dump` (`tomlkit`)                               |                                                                                  |
+| `csv`          | `.csv`                | (標準 `csv`)              | `csv.load` (標準 `csv` + 型推測, エラー処理)         | `csv.dump` (標準 `csv`)                               | `--fullscan` オプションで全行からヘッダ生成可。                                        |
+| `tsv`          | `.tsv`                | (標準 `csv`)              | `tsv.load` (`csv.load` の `delimiter='\t'` 版)       | `tsv.dump` (`csv.dump` の `delimiter='\t'` 版)        |                                                                                  |
+| `md`           | `.md`, `.mdtable`     | -                         | `md.load` (Markdownテーブル)                         | `md.dump` (Markdownテーブル)                          | 数値列の自動判定、`null_value` の指定。                                               |
+| `raw`          | (なし)                | -                         | `raw.load` (ファイル全体を文字列としてロード)        | `raw.dump` (文字列をそのままダンプ)                     |                                                                                  |
+| `env`          | `.env`, `.environ`    | -                         | `env.load` (テンプレートファイル + 環境変数)           | (なし)                                                | テンプレートの値を環境変数で置換。型変換指定可 (`VAR:int`)。                               |
+| `spreadsheet`  | (URL/IDパターン)      | `google-api-python-client`, `google-auth-oauthlib` | `spreadsheet.load` (Google Spreadsheet)            | (未実装)                                              | URLやIDで指定。1行目をヘッダとする辞書のリストを返す (デフォルト)。範囲未指定時はシート情報。 |
+| `(unknown)`    | (上記以外)            | `ruamel.yaml` (デフォルト) | `yaml.load` (デフォルト)                             | `yaml.dump` (デフォルト)                              | `setup()` で変更可能。                                                              |
+
+**実行例:**
+
+```python
+from dictknife import loading
+
+# JSONファイルのロード
+data_json = loading.loadfile("config.json")
+
+# YAML文字列のロード
+yaml_string = "name: MyApp\nversion: 1.0"
+data_yaml = loading.loads(yaml_string, format="yaml")
+
+# 辞書データをTOMLファイルにダンプ
+my_data = {"user": {"name": "Alice", "age": 30}}
+loading.dumpfile(my_data, "output.toml", format="toml")
+
+# CSVデータをロード (型推測あり)
+# data.csv:
+# name,age,active
+# Bob,25,true
+# Carol,,"false"
+csv_data = loading.loadfile("data.csv")
+# csv_data は [{'name': 'Bob', 'age': 25, 'active': True}, {'name': 'Carol', 'age': None, 'active': False}] のようになる
+
+# Markdownテーブルとしてダンプ
+table_data = [{"id":1, "value":"foo"}, {"id":2, "value":"bar"}]
+loading.dumpfile(table_data, "output.md", format="md")
+
+# envフォーマットの例
+# template.env.yaml の内容:
+#   app_name: APP_NAME
+#   debug_mode: DEBUG_MODE:bool
+#   port_number: PORT:int
+# 環境変数として APP_NAME="MyAPP", DEBUG_MODE="true", PORT="8080" が設定されている場合:
+# env_data = loading.loadfile("template.env.yaml")
+# env_data は {'app_name': 'MyAPP', 'debug_mode': True, 'port_number': 8080} のようになる
+
+# Google Spreadsheet の例 (別途認証設定が必要)
+# sheet_url = "https://docs.google.com/spreadsheets/d/<your_sheet_id>/edit#gid=0"
+# sheet_data = loading.loadfile(sheet_url, format="spreadsheet")
+# sheet_data は1行目をヘッダとする辞書のリスト (例: [{'colA': 'valA1', 'colB': 'valB1'}, ...])
+# または、範囲指定がない場合などでシート情報が返ることもあります。
+```
+
+### フォーマット固有オプション (`extra`引数)
+
+`dump` や `dumpfile` の `extra` 引数を通じて、各フォーマットのダンプ関数に固有のオプションを渡すことができます。
+例えば、`json.dump` は `indent` や `ensure_ascii` を `extra` で受け取ることができますが、`dictknife.loading.json.dump` のシグネチャで既にデフォルト値が設定されているため、通常は明示的に `extra` を使う必要は少ないかもしれません。コマンドラインツールでは、これらのオプションは `--<format>-<option_name>` (例: `--json-indent`) のような形で `ExtraArgumentsParsers` を介して渡されます。
+```

--- a/docs/apidoc/loading_modification.md
+++ b/docs/apidoc/loading_modification.md
@@ -1,0 +1,183 @@
+```markdown
+# `dictknife.loading.modification`
+
+このパッケージは、`dictknife.loading` のローダー ( `Loader` ) やダンパー ( `Dumper` ) のデフォルトの挙動を動的に変更するためのモジュール群を提供します。各モジュールは `setup(dispatcher)` 関数を公開しており、これを呼び出すことでディスパッチャの特定の動作が変更されます。
+
+通常、これらの modification は `dictknife` のコマンドラインインターフェースで特定のオプションが指定された際に内部的に適用されますが、ライブラリとして `dictknife.loading` を直接利用する際にも個別に適用することが可能です。
+
+## パッケージ内のヘルパー関数
+
+`dictknife.loading.modification` パッケージの `__init__.py` では、以下のヘルパー関数が定義されています。これらは主に各 modification モジュール内部で使用されます。
+
+*   `is_used(dispatcher, name)`: 指定された `name` の modification が既に `dispatcher` に適用済みかどうかを確認します。
+*   `use(dispatcher, name)`: 指定された `name` の modification を `dispatcher` に適用済みとして記録します。
+
+## 利用可能な Modification モジュール
+
+### `dictknife.loading.modification.compact`
+
+JSON形式で出力する際に、インデントなしのコンパクトな形式で出力するように変更します。
+
+*   **関数:** `setup(dispatcher)`
+*   **対象:** ダンパー (`dispatcher.dumper`)
+*   **変更内容:** `dispatcher.dumper.fn_map["json"]` のダンプ関数を、`indent=None` で呼び出すように変更します。
+
+**使用例:**
+
+```python
+from dictknife.loading import get_dumper
+from dictknife.loading.modification import compact
+import sys
+
+dumper = get_dumper("json") # 通常のJSONダンパーを取得
+data = {"name": "example", "version": 1, "items": [1, 2, 3]}
+
+print("--- Default JSON dump ---")
+dumper.dump(data, sys.stdout)
+# 出力例 (インデントあり):
+# {
+#   "items": [
+#     1,
+#     2,
+#     3
+#   ],
+#   "name": "example",
+#   "version": 1
+# }
+
+compact.setup(dumper) # compact modification を適用
+
+print("\n--- Compact JSON dump ---")
+dumper.dump(data, sys.stdout)
+# 出力例 (インデントなし):
+# {"items": [1, 2, 3], "name": "example", "version": 1}
+```
+
+### `dictknife.loading.modification.flatten`
+
+データを出力する際に、事前に辞書をフラット化 (ネストした辞書をキーを連結して一段階に展開) するように変更します。
+
+*   **関数:** `setup(dispatcher)`
+*   **対象:** ダンパー (`dispatcher.dumper`)
+*   **変更内容:** `dispatcher.dumper.fn_map` に登録されている全てのダンプ関数をラップし、ダンプ対象のデータを `dictknife.transform.flatten()` で前処理するようにします。
+
+**使用例:**
+
+```python
+from dictknife.loading import get_dumper
+from dictknife.loading.modification import flatten
+import sys
+
+dumper = get_dumper("json")
+data = {"user": {"name": "Alice", "age": 30}, "status": "active"}
+
+print("--- Default JSON dump (nested) ---")
+dumper.dump(data, sys.stdout)
+# 出力例:
+# {
+#   "status": "active",
+#   "user": {
+#     "age": 30,
+#     "name": "Alice"
+#   }
+# }
+
+flatten.setup(dumper) # flatten modification を適用
+
+print("\n--- Flattened JSON dump ---")
+dumper.dump(data, sys.stdout)
+# 出力例:
+# {
+#   "status": "active",
+#   "user.age": 30,
+#   "user.name": "Alice"
+# }
+```
+
+### `dictknife.loading.modification.unescape_unicode`
+
+入力ストリームからデータを読み込む際に、Unicodeエスケープシーケンス (`\uXXXX` 形式) をデコードするように変更します。
+
+*   **関数:** `setup(dispatcher)`
+*   **対象:** ローダー (`dispatcher.loader`)
+*   **変更内容:** `dispatcher.loader.fn_map` に登録されている全てのロード関数をラップし、入力ストリームから読み取った文字列に対して `.encode("utf-8").decode("unicode-escape")` を適用し、前後のクォートを除去する前処理を行います。
+
+**使用例:**
+
+```python
+from dictknife.loading import get_loader
+from dictknife.loading.modification import unescape_unicode
+from io import StringIO
+
+loader = get_loader("json") # JSONローダーを取得
+
+# UnicodeエスケープされたJSON文字列
+escaped_json_str = '"{\\"name\\": \\"\\u30c6\\u30b9\\u30c8\\u540d\\", \\"value\\": \\"\\u0041\\u0042\\u0043\\"}"' # クォートで囲まれた文字列中のJSON
+
+# modification なしの場合 (入力が文字列リテラルのため、Pythonが先にデコードしてしまう場合があるので注意)
+# この例ではStringIOでラップすることで、 modification の効果を明確にする
+# loader.load(StringIO(escaped_json_str)) -> 通常はエラーになるか、エスケープされたままの文字列として解釈される
+
+unescape_unicode.setup(loader) # unescape_unicode modification を適用
+
+data = loader.load(StringIO(escaped_json_str))
+print(data)
+# 出力例:
+# {'name': 'テスト名', 'value': 'ABC'}
+```
+*注意: `unescape_unicode` は入力文字列全体を一度読み込んで処理します。非常に大きなストリームには適さない場合があります。*
+
+### `dictknife.loading.modification.unescape_url`
+
+入力ストリームからデータを読み込む際に、URLエンコード (パーセントエンコーディング) された文字列をデコードするように変更します。
+
+*   **関数:** `setup(dispatcher)`
+*   **対象:** ローダー (`dispatcher.loader`)
+*   **変更内容:** `dispatcher.loader.fn_map` に登録されている全てのロード関数をラップし、入力ストリームから読み取った文字列に対して `urllib.parse.unquote_plus()` を適用し、前後のクォートを除去する前処理を行います。
+
+**使用例:**
+
+```python
+from dictknife.loading import get_loader
+from dictknife.loading.modification import unescape_url
+from io import StringIO
+
+loader = get_loader("json") # JSONローダーを取得 (他の形式でも動作しうる)
+
+# URLエンコードされたJSON文字列 (実際にはJSONである必要はないが、loaderが対応する形式にデコードされる)
+url_encoded_str = '"name=%E3%83%86%E3%82%B9%E3%83%88%20%E5%90%8D&value=A%2BB%20C"' # クォートで囲まれたURLエンコード文字列
+
+# modification なしの場合
+# loader.load(StringIO(url_encoded_str)) -> URLエンコードされたままの文字列として解釈される
+
+unescape_url.setup(loader) # unescape_url modification を適用
+
+# この modification は文字列をデコードするだけなので、
+# デコード後の文字列がloaderの期待する形式 (この場合はJSON) である必要がある。
+# この例では、デコード後がJSONではないため、JSONローダーではエラーになる。
+# ここではデコード処理そのものに焦点を当てる。
+# 実際の使用では、デコード後の文字列が適切な形式になるようにする。
+
+# 例として、デコード後の文字列を取得する処理をシミュレート
+# (実際にはloaderがこの処理を行う)
+from urllib.parse import unquote_plus
+temp_stream = StringIO(url_encoded_str)
+raw_content = temp_stream.read()
+if raw_content.startswith('"') and raw_content.endswith('"'): # クォート除去のシミュレーション
+    raw_content = raw_content[1:-1]
+decoded_string = unquote_plus(raw_content)
+print(f"Decoded string: {decoded_string}")
+# 出力例:
+# Decoded string: name=テスト 名&value=A+B C
+
+# loader に渡すのは、デコード後にJSONとしてパース可能な文字列である必要がある。
+# 例えば、URLエンコードされたJSONペイロードの場合:
+url_encoded_json = '"%7B%22name%22%3A%20%22%E3%83%86%E3%82%B9%E3%83%88%E5%90%8D%22%2C%20%22value%22%3A%20%22A%2BB%20C%22%7D"'
+data = loader.load(StringIO(url_encoded_json))
+print(data)
+# 出力例:
+# {'name': 'テスト名', 'value': 'A+B C'}
+
+```
+*注意: `unescape_url` は入力文字列全体を一度読み込んで処理します。非常に大きなストリームには適さない場合があります。*
+```

--- a/docs/apidoc/mkdict.md
+++ b/docs/apidoc/mkdict.md
@@ -1,0 +1,128 @@
+```markdown
+# `dictknife.mkdict`
+
+このモジュールは、特定のミニ言語構文で記述された一行の文字列から、Pythonの辞書または辞書のリストを生成する機能を提供します。コマンドラインツール `dictknife mkdict` のコアロジックでもあります。
+
+## `mkdict(line, *, separator="/", delimiter=";", accessor=_AccessorSupportList(make_dict), guess=guess, shared=None)`
+
+与えられた文字列 `line` を解析し、辞書または辞書のリストを構築して返します。
+
+*   `line` (str): 解析対象の文字列。独自のミニ言語構文で記述されます。
+*   `separator` (str, default: `/`): ネストされたキーを指定する際の区切り文字。例えば `parent/child` は `{"parent": {"child": ...}}` のように解釈されます。
+*   `delimiter` (str, default: `;`): 複数の辞書エントリを区切るための文字。この文字で区切られた場合、結果は辞書のリストになります。
+*   `accessor` (object, default: `_AccessorSupportList` instance): 内部的にキーと値の割り当てを行うアクセサオブジェクト。デフォルトの `_AccessorSupportList` は、パスの指定に応じてリストも適切に扱えるように拡張されたアクセサです。
+*   `guess` (callable, default: `dictknife.guessing.guess`): 値の型を推論する関数。文字列 "true", "false", "null", "10", "3.14" などが適切なPythonの型 (bool, None, int, float) に変換されます。
+*   `shared` (dict, default: `None`): 複数の `mkdict` 呼び出しや、内部のブロック間で共有される変数を格納するための辞書。`None` の場合は呼び出しごとに独立した変空間が使われます。
+
+**戻り値:** 生成された辞書、または辞書のリスト。
+
+### ミニ言語の主要構文
+
+`mkdict` が解釈する文字列 `line` は、以下のルールに基づいた構文を持ちます。
+
+1.  **キーと値のペア:**
+    スペース区切りで `キー 値` のように指定します。
+    例: `name Alice age 30` -> `{'name': 'Alice', 'age': 30}`
+
+2.  **ネストしたキー (separator):**
+    `separator` (デフォルト `/`) を使ってキーをネストできます。
+    例: `user/name Alice user/contact/email alice@example.com`
+    -> `{'user': {'name': 'Alice', 'contact': {'email': 'alice@example.com'}}}`
+
+3.  **複数の辞書 (delimiter):**
+    `delimiter` (デフォルト `;`) を使うと、複数の辞書からなるリストを生成できます。
+    例: `id 1 ; id 2` -> `[{'id': 1}, {'id': 2}]`
+
+4.  **値のグループ化 (ブロック `{}`):**
+    `{` と `}` で囲むことで、値をグループ化できます。これは主にネストした辞書を値として割り当てる際に使います。
+    例: `user { name Alice age 30 } status active`
+    -> `{'user': {'name': 'Alice', 'age': 30}, 'status': 'active'}`
+
+5.  **変数定義 (`@`):**
+    `@変数名 値` または `@変数名/ネストキー 値` で変数を定義できます。変数は内部の共有空間 (`shared` または `variables`) に保存されます。
+    例: `@default_user { name Unknown active false }`
+
+6.  **変数参照 (`&`):**
+    `&変数名` または `&変数名/ネストキー` で定義済みの変数を参照できます。
+    例: `user1 &default_user user2 { name Alice }` (user2 は default_user を部分的に上書き)
+
+7.  **リストの作成:**
+    キーの末尾に `separator` を付ける (例: `items/`) か、パスの途中で空のキー (`//`) や数値インデックスを指定することでリストやリスト内の要素を操作できます。
+    *   `items/ value1 items/ value2` -> `{'items': ['value1', 'value2']}`
+    *   `items//name valueA items//name valueB` -> `{'items': [{'name': 'valueA'}, {'name': 'valueB'}]}`
+    *   `items/0/name valueA items/1/name valueB` -> `{'items': [{'name': 'valueA'}, {'name': 'valueB'}]}`
+    *   `items/-1/property value` は、現在のリストの最後の要素に `property` を追加/更新します。
+
+8.  **エスケープ:**
+    `{{`, `}}`, `&&`, `@@` はそれぞれ `{`, `}`, `&`, `@` という文字そのものとして扱われます。
+
+9.  **値の型推論:**
+    値は `guess` 関数によって型が推論されます。
+    `"true"` -> `True`, `"10"` -> `10`, `"3.14"` -> `3.14`, `"null"` -> `None`。
+
+**実行例:**
+
+```python
+from dictknife.mkdict import mkdict
+from dictknife.langhelpers import make_dict # OrderedDictのため (Python 3.6+では不要かも)
+from dictknife.guessing import guess as default_guess
+from dictknife.mkdict import _AccessorSupportList
+
+# カスタムアクセサやguess関数も指定可能だが、通常はデフォルトで十分
+custom_accessor = _AccessorSupportList(make_dict=make_dict)
+
+# 基本的な例
+data1 = mkdict("name Alice age 30 active true")
+print(data1)
+# 出力: {'name': 'Alice', 'age': 30, 'active': True}
+
+# ネストとリスト
+data2 = mkdict("user/name Bob user/tags/ tag1 user/tags/ tag2 score 100.5")
+print(data2)
+# 出力: {'user': {'name': 'Bob', 'tags': ['tag1', 'tag2']}, 'score': 100.5}
+
+# デリミタを使ったリスト
+data3 = mkdict("type A value 1 ; type B value 2 ; type C value 3")
+print(data3)
+# 出力: [{'type': 'A', 'value': 1}, {'type': 'B', 'value': 2}, {'type': 'C', 'value': 3}]
+
+# ブロックと変数
+line4 = "@common_settings { debug false port 8080 } server1 { host localhost } server1/settings &common_settings ; server2 { host 192.168.1.100 } server2/settings &common_settings server2/settings/port 9000"
+data4 = mkdict(line4)
+print(data4)
+# 出力:
+# [
+#   {'server1': {'host': 'localhost', 'settings': {'debug': False, 'port': 8080}}},
+#   {'server2': {'host': '192.168.1.100', 'settings': {'debug': False, 'port': 9000}}}
+# ]
+
+# 共有変数を使った例
+shared_vars = {}
+mkdict("@shared_val initial", shared=shared_vars)
+data5_part1 = mkdict("item1 &shared_val", shared=shared_vars)
+mkdict("@shared_val updated", shared=shared_vars) # shared_vars内の値を更新
+data5_part2 = mkdict("item2 &shared_val", shared=shared_vars)
+
+print(f"Shared vars: {shared_vars}")
+print(f"Data5 Part1: {data5_part1}")
+print(f"Data5 Part2: {data5_part2}")
+# 出力:
+# Shared vars: {'shared_val': 'updated'}
+# Data5 Part1: {'item1': 'initial'}
+# Data5 Part2: {'item2': 'updated'}
+
+# リスト内の要素への詳細なアクセス
+line6 = "items//id 1 items/-1/name A items//id 2 items/-1/name B items/0/status active"
+data6 = mkdict(line6)
+print(data6)
+# 出力: {'items': [{'id': 1, 'name': 'A', 'status': 'active'}, {'id': 2, 'name': 'B'}]}
+```
+
+### 内部関数とクラス
+
+*   `_mkdict(...)`: `mkdict` のコアロジックを実装する再帰関数。
+*   `tokenize(line)`: `shlex` をベースにしたカスタムトークナイザ。入力行をミニ言語のトークンに分割します。
+*   `_AccessorSupportList`: `dictknife.accessing.Accessor` を継承し、リストのインデックス (`/0/`, `//`, `/-1/`) を特別扱いしてリスト操作をサポートする内部クラス。
+
+これらの内部コンポーネントは通常、`mkdict` 関数を通じて間接的に利用されます。
+```

--- a/docs/apidoc/naming.md
+++ b/docs/apidoc/naming.md
@@ -1,0 +1,222 @@
+```markdown
+# `dictknife.naming`
+
+このモジュールは、文字列の命名規則を変換するための関数群を提供します。例えば、スネークケース、ケバブケース、キャメルケース、パスカルケース間の変換や、文字列の正規化などを行います。
+
+## `normalize(name, ignore_rx=re.compile("[^0-9a-zA-Z_]+"))`
+
+与えられた `name` 文字列を正規化します。デフォルトでは、ハイフン `-` をアンダースコア `_` に置換した後、英数字とアンダースコア以外の文字をすべて除去します。
+
+*   `name`: 正規化する文字列。
+*   `ignore_rx`: 除去する文字パターンを指定する正規表現オブジェクト。デフォルトは `[^0-9a-zA-Z_]+`。
+
+**戻り値:** 正規化された文字列。
+
+**実行例:**
+
+```python
+from dictknife.naming import normalize
+
+name1 = normalize("My-Variable Name 123")
+# name1 is "My_VariableName_123"
+
+name2 = normalize("foo-bar*baz")
+# name2 is "foo_barbaz"
+
+# カスタム正規表現でアンダースコアも除去する例
+import re
+name3 = normalize("My_Variable_Name", ignore_rx=re.compile("[^0-9a-zA-Z]+"))
+# name3 is "MyVariableName"
+```
+
+## `snakecase(name, *, rx0=..., rx1=..., separator="_", other="-")`
+
+文字列 `name` をスネークケース (例: `snake_case_example`) に変換します。
+内部的に正規表現 `rx0` と `rx1` を使用して大文字と小文字の境界を検出し、`separator` (デフォルトは `_`) で区切ります。また、`other` (デフォルトは `-`) で指定された文字も `separator` に置換します。
+
+*   `name`: 変換する文字列。
+*   `separator`: 単語区切りに使用する文字。デフォルトは `_`。
+*   `other`: `separator` に置換される追加の文字。デフォルトは `-`。
+
+**戻り値:** スネークケースに変換された文字列。
+
+**実行例:**
+
+```python
+from dictknife.naming import snakecase
+
+s1 = snakecase("CamelCaseName")
+# s1 is "camel_case_name"
+
+s2 = snakecase("PascalCaseName")
+# s2 is "pascal_case_name"
+
+s3 = snakecase("already_snake_case")
+# s3 is "already_snake_case"
+
+s4 = snakecase("kebab-case-name")
+# s4 is "kebab_case_name"
+
+s5 = snakecase("HTTPResponseCode")
+# s5 is "http_response_code"
+
+s6 = snakecase("ABcDEF") # 連続する大文字の扱い
+# s6 is "a_bc_def"
+```
+
+## `kebabcase(name, *, rx0=..., rx1=..., separator="-", other="_")`
+
+文字列 `name` をケバブケース (例: `kebab-case-example`) に変換します。
+`snakecase` と同様のロジックですが、デフォルトの `separator` が `-`、`other` が `_` になります。
+
+*   `name`: 変換する文字列。
+*   `separator`: 単語区切りに使用する文字。デフォルトは `-`。
+*   `other`: `separator` に置換される追加の文字。デフォルトは `_`。
+
+**戻り値:** ケバブケースに変換された文字列。
+
+**実行例:**
+
+```python
+from dictknife.naming import kebabcase
+
+k1 = kebabcase("CamelCaseName")
+# k1 is "camel-case-name"
+
+k2 = kebabcase("PascalCaseName")
+# k2 is "pascal-case-name"
+
+k3 = kebabcase("already-kebab-case")
+# k3 is "already-kebab-case"
+
+k4 = kebabcase("snake_case_name")
+# k4 is "snake-case-name"
+
+k5 = kebabcase("HTTPResponseCode")
+# k5 is "http-response-code"
+```
+
+## `camelcase(name, *, soft=True)`
+
+文字列 `name` をキャメルケース (例: `camelCaseExample`) に変換します。
+
+*   `name`: 変換する文字列。
+*   `soft=True` (デフォルト): もし `name` の最初の文字が大文字の場合、パスカルケース (`PascalCaseExample`) として扱います。`False` の場合は、最初の文字が小文字になるように強制します。
+
+**戻り値:** キャメルケースまたはパスカルケースに変換された文字列。
+
+**実行例:**
+
+```python
+from dictknife.naming import camelcase
+
+c1 = camelcase("snake_case_name")
+# c1 is "snakeCaseName"
+
+c2 = camelcase("kebab-case-name")
+# c2 is "kebabCaseName"
+
+c3 = camelcase("PascalCaseName") # soft=True なので PascalCase のまま
+# c3 is "PascalCaseName"
+
+c4 = camelcase("PascalCaseName", soft=False) # soft=False なので先頭小文字
+# c4 is "pascalCaseName"
+
+c5 = camelcase("alreadyCamelCase")
+# c5 is "alreadyCamelCase"
+
+c6 = camelcase("Title Case Name")
+# c6 is "TitleCaseName" (pascalcase経由)
+```
+
+## `pascalcase(name, rx=re.compile(r"[\-_ ]"))`
+
+文字列 `name` をパスカルケース (例: `PascalCaseExample`) に変換します。デフォルトでは、アンダースコア `_`、ハイフン `-`、スペース ` ` を区切り文字として単語に分割し、各単語の先頭を大文字にして結合します。
+
+*   `name`: 変換する文字列。
+*   `rx`: 単語の区切り文字を定義する正規表現。デフォルトは `[\-_ ]`。
+
+**戻り値:** パスカルケースに変換された文字列。
+
+**実行例:**
+
+```python
+from dictknife.naming import pascalcase
+
+p1 = pascalcase("snake_case_name")
+# p1 is "SnakeCaseName"
+
+p2 = pascalcase("kebab-case-name")
+# p2 is "KebabCaseName"
+
+p3 = pascalcase("camelCaseName") # 先頭も大文字になる
+# p3 is "CamelCaseName"
+
+p4 = pascalcase("a_b_c")
+# p4 is "ABC"
+
+p5 = pascalcase("alreadyPascalCase")
+# p5 is "AlreadyPascalCase" (最初の単語として扱われる)
+
+p6 = pascalcase("title case words")
+# p6 is "TitleCaseWords"
+```
+
+## `titleize(name)`
+
+文字列 `name` の最初の文字を大文字にし、残りの文字はそのままにします (いわゆるタイトルケースとは異なり、単語の先頭を全て大文字化するわけではありません)。
+
+*   `name`: 変換する文字列。
+
+**戻り値:** 最初の文字が大文字化された文字列。`name` が空の場合は空文字列を返します。
+
+**実行例:**
+
+```python
+from dictknife.naming import titleize
+
+t1 = titleize("hello")
+# t1 is "Hello"
+
+t2 = titleize("world")
+# t2 is "World"
+
+t3 = titleize("AlreadyTitled")
+# t3 is "AlreadyTitled"
+
+t4 = titleize("")
+# t4 is ""
+
+t5 = titleize("1st")
+# t5 is "1st" (最初の文字が非アルファベットの場合、そのまま)
+```
+
+## `untitleize(name)`
+
+文字列 `name` の最初の文字を小文字にし、残りの文字はそのままにします。
+
+*   `name`: 変換する文字列。
+
+**戻り値:** 最初の文字が小文字化された文字列。`name` が空の場合は空文字列を返します。
+
+**実行例:**
+
+```python
+from dictknife.naming import untitleize
+
+u1 = untitleize("Hello")
+# u1 is "hello"
+
+u2 = untitleize("WORLD")
+# u2 is "wORLD"
+
+u3 = untitleize("alreadyUntitled")
+# u3 is "alreadyUntitled"
+
+u4 = untitleize("")
+# u4 is ""
+
+u5 = untitleize("1St")
+# u5 is "1St" (最初の文字が非アルファベットの場合、そのまま)
+```
+```

--- a/docs/apidoc/operators.md
+++ b/docs/apidoc/operators.md
@@ -1,0 +1,218 @@
+```markdown
+# `dictknife.operators`
+
+このモジュールは、値のフィルタリングや条件評価に使用できる演算子クラスとヘルパー関数を提供します。
+主に `dictknife.walkers.DictWalker` などで、探索するキーや値を動的に照合する際に利用されます。
+
+## `apply(q, v, *args)`
+
+条件 `q` を値 `v` (およびオプションの追加引数 `*args`) に適用します。
+
+*   `q`: 適用する条件。
+    *   `q` が呼び出し可能 (callable) な場合: `q(v, *args)` を呼び出し、その結果を返します。
+    *   `q` が呼び出し可能でない場合: `q == v` の結果を返します。
+*   `v`: 条件を適用する対象の値。
+*   `*args`: `q` が呼び出し可能な場合に渡される追加の引数。
+
+**戻り値:** 条件の評価結果 (通常は `bool`)。
+
+**実行例:**
+
+```python
+from dictknife.operators import apply, Regexp
+
+# q が呼び出し可能でない場合 (単純な比較)
+print(apply("hello", "hello")) # True
+print(apply("hello", "world")) # False
+
+# q が呼び出し可能な場合 (Regexp オブジェクト)
+rx = Regexp(r"he.lo")
+print(apply(rx, "hello")) # <re.Match object; span=(0, 5), match='hello'> (True相当)
+print(apply(rx, "world")) # None (False相当)
+
+# q が呼び出し可能な場合 (カスタム関数)
+def is_even(n):
+    return n % 2 == 0
+print(apply(is_even, 4)) # True
+print(apply(is_even, 3)) # False
+```
+
+## `Regexp` クラス
+
+正規表現によるマッチングを行うための演算子です。
+
+### `__init__(self, rx)`
+
+*   `rx`: 正規表現パターン。文字列またはコンパイル済みの正規表現オブジェクト (`re.Pattern`) を指定できます。文字列で渡された場合は内部で `re.compile()` されます。
+
+### `__call__(self, v, *args)`
+
+値 `v` (文字列であると期待される) がコンストラクタで指定された正規表現 `rx` にマッチするかどうかを評価します。`re.search()` を使用するため、文字列の一部にマッチすれば成功とみなされます。
+
+*   `v`: マッチング対象の文字列。
+*   `*args`: 無視されます。
+
+**戻り値:** マッチした場合は `re.Match` オブジェクト、マッチしない場合は `None`。
+
+**実行例:**
+
+```python
+from dictknife.operators import Regexp, apply
+import re
+
+# 文字列で正規表現を指定
+op_str = Regexp(r"^[a-zA-Z]+$")
+print(bool(apply(op_str, "HelloWorld"))) # True
+print(bool(apply(op_str, "HelloWorld123"))) # False
+
+# コンパイル済み正規表現オブジェクトを指定
+compiled_rx = re.compile(r"\d{3}-\d{4}")
+op_compiled = Regexp(compiled_rx)
+print(bool(apply(op_compiled, "123-4567"))) # True
+print(bool(apply(op_compiled, "abc-defg"))) # False
+```
+
+## `Any` クラス (および `ANY` インスタンス)
+
+常に `True` を返す演算子です。どのような値に対してもマッチします。
+シングルトンインスタンス `ANY` が提供されています。
+
+### `__call__(self, v, *args)`
+
+*   `v`: 任意の値。
+*   `*args`: 無視されます。
+
+**戻り値:** 常に `True`。
+
+**実行例:**
+
+```python
+from dictknife.operators import ANY, apply # または from dictknife.operators import Any; ANY = Any()
+
+print(apply(ANY, "anything"))    # True
+print(apply(ANY, None))          # True
+print(apply(ANY, 123))           # True
+```
+
+## `Not` クラス
+
+指定された条件演算子の結果を否定する演算子です。
+
+### `__init__(self, value)`
+
+*   `value`: 否定する条件。これはリテラル値、または他の演算子インスタンス (`Regexp`, `Any`, `Or`, `And`) などです。
+
+### `__call__(self, v, *args)`
+
+内部で `apply(self.args, v, *args)` を呼び出し、その結果を論理否定 (`not`) して返します。
+
+*   `v`: 評価対象の値。
+*   `*args`: 内部の `apply` に渡される追加引数。
+
+**戻り値:** 指定された条件の評価結果の否定 (`bool`)。
+
+**実行例:**
+
+```python
+from dictknife.operators import Not, Regexp, apply
+
+# "hello" ではない場合に True
+op_not_hello = Not("hello")
+print(apply(op_not_hello, "world")) # True
+print(apply(op_not_hello, "hello")) # False
+
+# 数字で始まらない場合に True
+rx_digits = Regexp(r"^\d")
+op_not_starts_with_digit = Not(rx_digits)
+print(apply(op_not_starts_with_digit, "abc"))  # True (rx_digits は None を返すので not None は True)
+print(apply(op_not_starts_with_digit, "1abc")) # False (rx_digits は Match オブジェクトを返すので not Match は False)
+```
+
+## `Or` クラス
+
+複数の条件演算子のうち、いずれか一つでも `True` を返せば `True` を返す演算子 (論理OR)。
+
+### `__init__(self, args)`
+
+*   `args`: 条件のリストまたはタプル。各要素はリテラル値や他の演算子インスタンスです。
+
+### `__call__(self, v, *args)`
+
+`args` 内の各条件 `e` について `apply(e, v, *args)` を順に評価し、最初に `True` となった時点で `True` を返します。全ての条件が `False` の場合は `False` を返します。
+
+*   `v`: 評価対象の値。
+*   `*args`: 内部の `apply` に渡される追加引数。
+
+**戻り値:** いずれかの条件が真であれば `True`、そうでなければ `False`。
+
+**実行例:**
+
+```python
+from dictknife.operators import Or, Regexp, apply
+
+# "apple", "banana", "cherry" のいずれかであれば True
+op_fruits = Or(["apple", "banana", "cherry"])
+print(apply(op_fruits, "banana"))  # True
+print(apply(op_fruits, "orange"))  # False
+
+# "error" を含むか、全て大文字であれば True
+rx_error = Regexp("error")
+rx_all_caps = Regexp(r"^[A-Z]+$")
+op_or_condition = Or([rx_error, rx_all_caps])
+print(apply(op_or_condition, "This is an error message")) # True (rx_error にマッチ)
+print(apply(op_or_condition, "WARNING"))                 # True (rx_all_caps にマッチ)
+print(apply(op_or_condition, "Normal message"))          # False
+```
+
+## `And` クラス
+
+複数の条件演算子のすべてが `True` を返す場合にのみ `True` を返す演算子 (論理AND)。
+
+### `__init__(self, args)`
+
+*   `args`: 条件のリストまたはタプル。各要素はリテラル値や他の演算子インスタンスです。
+
+### `__call__(self, v, *args)`
+
+`args` 内の各条件 `e` について `apply(e, v, *args)` を順に評価し、最初に `False` となった時点で `False` を返します。全ての条件が `True` の場合は `True` を返します。
+
+*   `v`: 評価対象の値。
+*   `*args`: 内部の `apply` に渡される追加引数。
+
+**戻り値:** すべての条件が真であれば `True`、そうでなければ `False`。
+
+**実行例:**
+
+```python
+from dictknife.operators import And, Not, Regexp, apply
+
+# "admin" であり、かつ "password" ではない場合に True (例: ユーザー名として適切か)
+op_user_check = And(["admin", Not("password")]) # "admin" はリテラル値との比較
+# この例は意図通りに動かない可能性あり。"admin"という文字列そのものと比較するため。
+# 正しくは以下のように Regexp を使うか、あるいは apply の第一引数が評価対象の値と等しいかを期待する。
+
+# "admin" という文字列に一致し、かつ "password" という文字列には一致しない場合
+op_user_check_strict = And([Regexp("^admin$"), Not(Regexp("^password$"))])
+# apply(op_user_check_strict, "admin") -> True
+# apply(op_user_check_strict, "password") -> False
+# apply(op_user_check_strict, "user") -> False
+
+
+# 3文字以上で、かつ全てアルファベットである場合に True
+rx_min_len_3 = Regexp(r".{3,}")
+rx_alpha_only = Regexp(r"^[a-zA-Z]+$")
+op_alpha_3plus = And([rx_min_len_3, rx_alpha_only])
+
+print(apply(op_alpha_3plus, "abc"))    # True
+print(apply(op_alpha_3plus, "ab"))     # False (長さが足りない)
+print(apply(op_alpha_3plus, "abc1"))   # False (数字が含まれる)
+print(apply(op_alpha_3plus, "longerword")) # True
+
+# テストコードで見られた組み合わせ例
+# Not("x") AND "xx" AND Not("xxx")
+op_complex = And([Not("x"), "xx", Not("xxx")])
+print(apply(op_complex, "x"))   # False
+print(apply(op_complex, "xx"))  # True
+print(apply(op_complex, "xxx")) # False
+```
+```

--- a/docs/apidoc/pp.md
+++ b/docs/apidoc/pp.md
@@ -1,0 +1,144 @@
+```markdown
+# `dictknife.pp`
+
+このモジュールは、Pythonのデータ構造 (主に辞書やリスト) を人間が読みやすい形に整形 (pretty print) して出力するためのユーティリティを提供します。
+
+## `pp(d, out=None)`
+
+データ `d` を整形して `out` (デフォルトは標準出力 `sys.stdout`) に出力します。
+内部では `json.dump()` を利用しており、以下のデフォルト設定で呼び出されます:
+*   `sort_keys=True` (キーでソートされる)
+*   `indent=2` (2スペースでインデント)
+*   `ensure_ascii=False` (非ASCII文字をそのまま出力)
+*   `default=str` (JSONシリアライズ不可能なオブジェクトは `str()` で文字列化)
+
+もし `json.dump()` が `TypeError` (例えば、ソート不可能な型のキーが存在する場合など) を送出した場合、`sort_keys=False` として再度 `json.dump()` を試みます。
+
+*   `d`: 出力するデータ構造。
+*   `out`: 出力先のストリームオブジェクト。デフォルトは `sys.stdout`。
+
+**実行例:**
+
+```python
+from dictknife.pp import pp
+import sys
+from io import StringIO
+
+data = {
+    "name": "テストユーザー",
+    "age": 30,
+    "active": True,
+    "address": {"city": "東京", "zip": None},
+    "tags": ["Python", "dictknife"]
+}
+
+# 標準出力へ出力
+# pp(data)
+# 出力結果 (標準出力に):
+# {
+#   "active": true,
+#   "address": {
+#     "city": "東京",
+#     "zip": null
+#   },
+#   "age": 30,
+#   "name": "テストユーザー",
+#   "tags": [
+#     "Python",
+#     "dictknife"
+#   ]
+# }
+
+# StringIO を使って文字列として取得
+buffer = StringIO()
+pp(data, out=buffer)
+output_str = buffer.getvalue()
+print(output_str)
+# 出力結果 (printによって):
+# {
+#   "active": true,
+#   "address": {
+#     "city": "東京",
+#     "zip": null
+#   },
+#   "age": 30,
+#   "name": "テストユーザー",
+#   "tags": [
+#     "Python",
+#     "dictknife"
+#   ]
+# }
+
+# ソート不可能なキーを含む場合のフォールバック (例として)
+data_unsortable = {
+    1: "one",
+    None: "null_key", # 通常、キーにNoneは推奨されないが、TypeErrorの例として
+    "b": "bee"
+}
+# pp(data_unsortable) # Python 3では sort_keys=True でも TypeError にならないことがある
+                      # json.dump のデフォルトの挙動に依存
+                      # この例では TypeError が発生しにくいが、もし発生した場合は sort_keys=False で試行される
+```
+
+## `indent(n, prefix=None, newline=True)`
+
+指定されたインデント `n` (スペース数) を付けて標準出力の内容を整形するためのコンテキストマネージャです。
+`with` ブロック内の標準出力 (`sys.stdout`) への書き込みを一時的にキャプチャし、ブロックを抜ける際にキャプチャした内容全体にインデントとオプションのプレフィックスを適用して、元の標準出力へ書き出します。
+
+*   `n`: インデントするスペースの数。
+*   `prefix=None`: インデントされたブロック全体の前に挿入する文字列。
+*   `newline=True`: `prefix` が指定された場合、`prefix` の後に改行を挿入するかどうか。
+
+**コンテキストマネージャが `yield` する値:**
+ブロック内で標準出力の代わりに書き込みに使用できる `io.StringIO` バッファ。ただし、通常はブロック内で普通に `print()` などを使用すれば、それがキャプチャされます。
+
+**実行例:**
+
+```python
+from dictknife.pp import indent, pp
+
+data1 = {"id": 1, "value": "first"}
+data2 = {"id": 2, "value": "second"}
+
+print("Raw output:")
+pp(data1)
+
+print("\nIndented output:")
+with indent(4, prefix="-- Start Block --"):
+    print("This is the first line inside the block.")
+    pp(data1) # ppも標準出力を使うのでインデントされる
+    print("And another line.")
+    with indent(4, prefix="---- Nested Block ----"): # ネストも可能
+        pp(data2)
+    print("Back to first level of indent.")
+print("-- End Block -- (This line is not indented by the context manager)")
+
+# 出力結果:
+# Raw output:
+# {
+#   "id": 1,
+#   "value": "first"
+# }
+#
+# Indented output:
+# -- Start Block --
+#     This is the first line inside the block.
+#     {
+#       "id": 1,
+#       "value": "first"
+#     }
+#     And another line.
+#     ---- Nested Block ----
+#         {
+#           "id": 2,
+#           "value": "second"
+#         }
+#     Back to first level of indent.
+# -- End Block -- (This line is not indented by the context manager)
+
+# `yield` されるバッファを直接使う例 (あまり一般的ではない)
+# with indent(2) as buf:
+#     buf.write("Hello from buffer\n")
+#     print("Hello from print", file=buf) # このようにバッファを指定する必要がある
+```
+```

--- a/docs/apidoc/shape.md
+++ b/docs/apidoc/shape.md
@@ -1,0 +1,127 @@
+```markdown
+# `dictknife.shape`
+
+このモジュールは、与えられたPythonのデータ構造 (辞書やリスト) を解析し、その「形状」やスキーマの概要を抽出する機能を提供します。具体的には、データ内の各パス、そのパスで見つかる値の型、および代表的なサンプル値をリストアップします。
+コマンドラインツール `dictknife shape` のコアロジックでもあります。
+
+## `shape(d, traverse=Traverser().traverse, aggregate=_build_pathlist_from_state, *, squash=False, skiplist=False, separator="/", transform=as_jsonpointer)`
+
+入力データ `d` の形状を解析し、結果を `Row` オブジェクトのリストとして返します。
+
+*   `d`: 解析対象の辞書またはリスト。
+*   `traverse` (callable, default: `Traverser().traverse`): データ構造を走査し、パスと値の情報を収集する関数。通常はデフォルトのままで使用します。
+*   `aggregate` (callable, default: `_build_pathlist_from_state`): `traverse` によって収集された情報を集約し、最終的な `Row` のリストを生成する関数。通常はデフォルトのままで使用します。
+*   `squash` (bool, default: `False`): `True` の場合、入力データがリストで、かつその要素が辞書である場合に、パスの先頭に来るリスト要素を示すマーカー (`[]/`) を除去します。例えば、`[]/person/name` が `person/name` になります。
+*   `skiplist` (bool, default: `False`): `True` の場合、パスの末尾がリスト要素マーカー (`[]`) で終わるようなエントリ (例: `person/skills/[]`) を結果から除外します。これはリスト自体ではなく、リストの *要素* の型や例を示します。
+*   `separator` (str, default: `/`): 出力されるパス文字列内で、階層を区切るために使用される文字。
+*   `transform` (callable, default: `dictknife.langhelpers.as_jsonpointer`): パスの各要素 (キーやリストマーカー) を文字列に変換する際に使用される関数。デフォルトではJSON Pointerの仕様に従い `/` や `~` をエスケープします。
+
+**戻り値:** `Row` namedtuple のリスト。各 `Row` オブジェクトは以下のフィールドを持ちます。
+    *   `path` (str): データ構造内の要素へのパス。オプショナルな要素の場合、先頭に `?` が付きます。
+    *   `type` (list): そのパスで見つかった値の型 (`type` オブジェクト) のリスト。複数の型が見つかった場合は、それら全てが含まれます (ソート済み)。
+    *   `example` (any): そのパスで見つかった値の代表的な例 (最初に見つかった値)。
+
+### `Row` namedtuple
+
+`Row = namedtuple("Row", "path, type, example")` として定義されています。
+
+### 内部クラスと関数
+
+*   `Traverser`: データ構造を再帰的に走査するクラス。
+    *   `_State`: `Traverser` が収集した中間情報を保持する内部クラス。
+*   `_build_pathlist_from_state`: `_State` オブジェクトから最終的な `Row` リストを構築する関数。
+
+これらの内部コンポーネントは通常、`shape` 関数を通じて間接的に利用されます。
+
+**実行例:**
+
+```python
+from dictknife.shape import shape, Row # Row は戻り値の型確認用にインポート
+from dictknife.langhelpers import as_jsonpointer # デフォルトの transform 関数
+
+data1 = {
+    "name": "Alice",
+    "age": 30,
+    "active": True,
+    "address": {"city": "Tokyo", "zip_code": "100-0000"},
+    "tags": ["python", "developer", "data"]
+}
+
+shape_info1 = shape(data1)
+for row in shape_info1:
+    print(f"Path: {row.path}, Types: {[t.__name__ for t in row.type]}, Example: {row.example!r}")
+# 出力例 (順不同の可能性あり):
+# Path: active, Types: ['bool'], Example: True
+# Path: address, Types: ['dict'], Example: {'city': 'Tokyo', 'zip_code': '100-0000'}
+# Path: address/city, Types: ['str'], Example: 'Tokyo'
+# Path: address/zip_code, Types: ['str'], Example: '100-0000'
+# Path: age, Types: ['int'], Example: 30
+# Path: name, Types: ['str'], Example: 'Alice'
+# Path: tags, Types: ['list'], Example: ['python', 'developer', 'data']
+# Path: tags/[], Types: ['str'], Example: 'python'
+
+print("-" * 20)
+
+data2 = [
+    {"id": 1, "type": "A", "value": 100, "optional_field": "present"},
+    {"id": 2, "type": "B", "value": 200},
+    {"id": 3, "type": "A", "value": 150.5, "tags": ["tag1"]},
+]
+
+# squash と skiplist の効果を見る
+shape_info2_default = shape(data2)
+print("--- Default ---")
+for row in shape_info2_default:
+    print(f"Path: {row.path}, Types: {[t.__name__ for t in row.type]}, Example: {row.example!r}")
+# 出力例 (抜粋):
+# Path: [], Types: ['dict'], Example: {'id': 1, 'type': 'A', 'value': 100, 'optional_field': 'present'}
+# Path: []/id, Types: ['int'], Example: 1
+# Path: []/type, Types: ['str'], Example: 'A'
+# Path: []/value, Types: ['float', 'int'], Example: 100
+# Path: ?[]/optional_field, Types: ['str'], Example: 'present'
+# Path: ?[]/tags, Types: ['list'], Example: ['tag1']
+# Path: ?[]/tags/[], Types: ['str'], Example: 'tag1'
+
+
+shape_info2_squashed = shape(data2, squash=True)
+print("\n--- Squashed ---")
+for row in shape_info2_squashed:
+    print(f"Path: {row.path}, Types: {[t.__name__ for t in row.type]}, Example: {row.example!r}")
+# 出力例 (抜粋, []/ が除去される):
+# Path: id, Types: ['int'], Example: 1
+# Path: type, Types: ['str'], Example: 'A'
+# Path: value, Types: ['float', 'int'], Example: 100
+# Path: ?optional_field, Types: ['str'], Example: 'present'
+# Path: ?tags, Types: ['list'], Example: ['tag1']
+# Path: ?tags/[], Types: ['str'], Example: 'tag1' (tags自体がオプショナルなので、その子もオプショナル扱いになることがある)
+
+
+shape_info2_squash_skip = shape(data2, squash=True, skiplist=True)
+print("\n--- Squashed & Skiplist ---")
+for row in shape_info2_squash_skip:
+    print(f"Path: {row.path}, Types: {[t.__name__ for t in row.type]}, Example: {row.example!r}")
+# 出力例 (抜粋, tags/[] がなくなる):
+# Path: id, Types: ['int'], Example: 1
+# Path: type, Types: ['str'], Example: 'A'
+# Path: value, Types: ['float', 'int'], Example: 100
+# Path: ?optional_field, Types: ['str'], Example: 'present'
+# Path: ?tags, Types: ['list'], Example: ['tag1']
+
+# transform を変える例 (JSON Pointerエスケープをしない)
+def no_transform(x): return str(x)
+data3 = {"foo/bar": 1}
+shape_info3_no_transform = shape(data3, transform=no_transform)
+print("\n--- No Transform ---")
+for row in shape_info3_no_transform:
+    print(f"Path: {row.path}")
+# 出力: Path: foo/bar
+
+shape_info3_default_transform = shape(data3) # default is as_jsonpointer
+print("\n--- Default Transform (as_jsonpointer) ---")
+for row in shape_info3_default_transform:
+    print(f"Path: {row.path}")
+# 出力: Path: foo~1bar
+```
+
+このモジュールは、未知のデータ構造の概要を把握したり、複数のデータインスタンスから共通のスキーマを推測したり、あるいは設定ファイルのテンプレートを生成する際などに役立ちます。
+```

--- a/docs/apidoc/swaggerknife_modules.md
+++ b/docs/apidoc/swaggerknife_modules.md
@@ -1,0 +1,55 @@
+```markdown
+# `dictknife.swaggerknife` (サブモジュール群)
+
+`dictknife.swaggerknife` パッケージは、Swagger/OpenAPIドキュメントの操作に特化した機能を提供するサブモジュール群を含んでいます。`swaggerknife` コマンドラインツールはこれらのモジュールを利用しています。
+
+## `flatten.py` - `definitions` セクションのフラット化
+
+Swagger/OpenAPIドキュメントの `definitions` セクション (または `components/schemas` に相当) 内のネストしたスキーマ定義をフラット化します。
+
+*   **`flatten(data, replace=True)`**:
+    *   入力 `data` (Swagger/OpenAPIドキュメント全体) の `definitions` セクションを処理対象とします。
+    *   `dictknife.jsonknife.lifting.Flattener` を利用し、各トップレベル定義内のインラインオブジェクトや配列アイテムのスキーマを、新しい名前で `definitions` セクション直下に「持ち上げ」ます。
+    *   `replace=True` (デフォルト) の場合、元の場所には持ち上げられた定義への `$ref` が残ります。
+    *   結果として、`definitions` セクションがよりフラットで再利用しやすい構造になります。
+
+**注意:** この `flatten` は、OpenAPI v2 の `definitions` を直接参照しています。v3 の `components/schemas` を対象とする場合は、呼び出し側でデータを調整する必要があるかもしれません。
+
+## `json2swagger.py` - JSONデータからのSwagger/OpenAPIスキーマ生成
+
+1つまたは複数のJSONデータサンプルから、Swagger/OpenAPIのスキーマ定義を推測し、生成します。
+
+*   **`Detector` クラス**:
+    *   入力JSONデータを再帰的に解析し、各要素の型、出現頻度、子要素の情報などを収集して中間表現 (`info` 辞書) を構築します。
+    *   `resolve_type()`: Pythonの型をJSON Schemaの型文字列に変換。
+*   **`Emitter` クラス**:
+    *   `Detector` が生成した `info` と、オプションの `annotations` (外部からのスキーマへの追加情報) を元に、Swagger/OpenAPIのスキーマ定義 (`definitions` セクションに入る形式) を構築します。
+    *   `make_signature()`: `info` からスキーマの構造的シグネチャを生成し、同じ構造のスキーマが同じ定義名で再利用されるようにします (`prestring.NameStore` を利用)。
+    *   `make_object_schema()`, `make_array_schema()`, `make_primitive_schema()`: `info` に基づいて各型のスキーマを再帰的に生成し、`definitions` に登録後、それへの `$ref` を返します。
+    *   `required` プロパティは出現頻度から推測されます。
+    *   `example` は観測された値から設定されます。
+*   **アノテーション**: 外部ファイルから特定のパス (`JSON Pointer`風) に対応するスキーマ属性 (例: `description`, `format`, 手動での型指定) を提供することで、生成結果をカスタマイズできます。
+
+## `migration.py` - Swagger/OpenAPIドキュメントのマイグレーションフレームワーク
+
+複数のファイルにまたがる可能性のあるSwagger/OpenAPIドキュメント群に対して、一連の変換処理 (マイグレーション) を行い、その結果を元のファイル構造に書き戻したり、差分を表示したりするための汎用的なフレームワークです。
+
+*   **`Migration` クラス**:
+    *   `__init__(resolver, dump_options=None, transform=None)`:
+        *   `resolver`: `ExternalFileResolver` を使用し、処理対象の全ファイルにアクセス。
+        *   `transform`: (オプション) マイグレーションロジック適用後に、各ドキュメントデータに最終的な変換を施す関数。
+    *   `migrate(dry_run=False, inplace=False, savedir=None, ...)`: マイグレーション処理のメインメソッド。
+        1.  `_prepare()`: `Bundler` の `Scanner` と同様に、全参照ファイルをスキャンし、`item_map` (処理対象の全定義アイテム) を構築。
+        2.  コンテキストマネージャ (`_migrate` または `_migrate_dryrun_and_diff`) が `_Updater` インスタンスを `yield`。
+        3.  呼び出し側 (具体的なマイグレーションスクリプト) が `_Updater` を使って `item_map` 内のドキュメントに変更を加える。
+        4.  コンテキスト終了後、`_Differ` が変更前後の差分を計算。
+            *   `dry_run`: 差分を表示。
+            *   実処理: 変更があったファイルを `savedir` (または元の場所へ `inplace`) に書き出す。書き出し前に `transform` 関数が適用される。
+*   **`_Updater` クラス**:
+    *   ドキュメントの変更操作 (値の更新 `update()`, `update_by_path()` や削除 `pop()`, `pop_by_path()`) を提供。
+    *   変更は `ChainMap` や内部的なマーカー (`_Empty`) を使って記録され、元のオブジェクトを直接変更しない形で行われることがあります。
+*   **`_Differ` クラス**:
+    *   `_Updater` によって加えられた変更の前後の状態を比較し、`dictknife.diff.diff` を使って差分を生成します。
+
+このフレームワーク自体は特定のバージョン移行ロジック (例: OpenAPI v2 to v3) を含んでいませんが、そのようなロジックを実装するための基盤となります。開発者は `_Updater` を使って必要な変更を行い、`Migration` クラスがファイルI/Oや差分表示を処理します。
+```

--- a/docs/apidoc/transform.md
+++ b/docs/apidoc/transform.md
@@ -1,0 +1,286 @@
+```markdown
+# `dictknife.transform`
+
+このモジュールは、辞書やリストのデータ構造を様々な形式に変換したり、特定の条件に基づいて要素を抽出・変更したりするための関数群を提供します。コマンドラインツール `dictknife transform` のコアロジックの一部としても利用されます。
+
+## `flatten(d, *, sep="/")`
+
+ネストされた辞書やリスト `d` を、キーがフラット化された一層の辞書に変換します。
+ネストしたキーは `sep` (デフォルトは `/`) で連結されます。リストのインデックスもキーの一部として扱われます。
+
+*   `d`: フラット化する対象の辞書またはリスト。
+*   `sep` (str, default: `/`): ネストしたキーを連結する際のセパレータ。
+
+**戻り値:** フラット化された辞書。
+
+**実行例:**
+
+```python
+from dictknife.transform import flatten
+
+data = {
+    "user": {
+        "name": "Alice",
+        "age": 30,
+        "emails": ["alice@example.com", "personal@example.net"]
+    },
+    "status": "active"
+}
+
+flat_data = flatten(data)
+print(flat_data)
+# 出力 (キーの順序は不定):
+# {
+#   'user/name': 'Alice',
+#   'user/age': 30,
+#   'user/emails/0': 'alice@example.com',
+#   'user/emails/1': 'personal@example.net',
+#   'status': 'active'
+# }
+
+# セパレータを変更
+flat_data_dot_sep = flatten(data, sep=".")
+print(flat_data_dot_sep)
+# 出力 (キーの順序は不定):
+# {
+#   'user.name': 'Alice',
+#   'user.age': 30,
+#   'user.emails.0': 'alice@example.com',
+#   'user.emails.1': 'personal@example.net',
+#   'status': 'active'
+# }
+```
+*注意: 値が単純な非コンテナ型の場合、キーは `None` となり、値はそのまま (ただし文字列の場合はJSON Pointerエスケープされる) になります。例: `flatten("text")` -> `{None: "text"}`*
+
+## `unflatten(d, *, sep="/", accessor=accessing.Accessor())`
+
+`flatten` 関数によってフラット化された辞書 `d` を、元のネストされた構造 (辞書やリスト) に戻します。
+キーは `sep` (デフォルトは `/`) を基準に分割され、階層構造が復元されます。数値のみのキーはリストのインデックスとして解釈しようとします。
+
+*   `d`: アンフラット化する対象のフラットな辞書。
+*   `sep` (str, default: `/`): キーを分割するためのセパレータ。
+*   `accessor` (object, default: `dictknife.accessing.Accessor()` instance): 内部でネスト構造を構築する際に使用するアクセサ。
+
+**戻り値:** ネストされた辞書またはリスト。
+
+**実行例:**
+
+```python
+from dictknife.transform import unflatten
+
+flat_data = {
+    'user/name': 'Alice',
+    'user/age': 30,
+    'user/emails/0': 'alice@example.com',
+    'user/emails/1': 'personal@example.net',
+    'status': 'active'
+}
+
+nested_data = unflatten(flat_data)
+print(nested_data)
+# 出力:
+# {
+#   'user': {
+#     'name': 'Alice',
+#     'age': 30,
+#     'emails': ['alice@example.com', 'personal@example.net']
+#   },
+#   'status': 'active'
+# }
+
+flat_data_list_only = {
+    '0/name': 'item0',
+    '1/name': 'item1'
+}
+nested_list = unflatten(flat_data_list_only)
+print(nested_list)
+# 出力: [{'name': 'item0'}, {'name': 'item1'}]
+```
+
+## `rows(d, *, kname="name", vname="value")`
+
+辞書 `d` を、各キーと値のペアを行オブジェクト (辞書) とするリストに変換します。
+
+*   `d`: 変換対象の辞書。
+*   `kname` (str, default: `"name"`): 結果の行オブジェクト内で、元のキーを格納する際のキー名。
+*   `vname` (str, default: `"value"`): 結果の行オブジェクト内で、元の値を格納する際のキー名。
+
+**戻り値:** 行オブジェクト (辞書) のリスト。
+
+**実行例:**
+
+```python
+from dictknife.transform import rows
+
+data = {"name": "Alice", "age": 30, "city": "Tokyo"}
+row_list = rows(data)
+print(row_list)
+# 出力:
+# [
+#   {'name': 'name', 'value': 'Alice'},
+#   {'name': 'age', 'value': 30},
+#   {'name': 'city', 'value': 'Tokyo'}
+# ]
+
+row_list_custom_names = rows(data, kname="key", vname="val")
+print(row_list_custom_names)
+# 出力:
+# [
+#   {'key': 'name', 'val': 'Alice'},
+#   {'key': 'age', 'val': 30},
+#   {'key': 'city', 'val': 'Tokyo'}
+# ]
+```
+
+## `update_keys(d, *, key, coerce=str)`
+
+辞書 `d` (およびネストされた辞書) 内のすべてのキーを、指定された `key` 関数によって変換します。この操作は **破壊的** (元の辞書を変更) です。
+
+*   `d`: キーを変換する対象の辞書。
+*   `key` (callable): 各キー (`str` 型に `coerce` された後) を引数に取り、変換後のキー文字列を返す関数。
+*   `coerce` (callable, default: `str`): キーを `key` 関数に渡す前に適用する型変換関数。
+
+**戻り値:** キーが変換された元の辞書オブジェクト `d`。
+
+**実行例:**
+
+```python
+from dictknife.transform import update_keys
+from dictknife.naming import camelcase # dictknife.naming からインポート
+
+data = {"first_name": "Alice", "last_name": "Smith", "contact_info": {"email_address": "alice@example.com"}}
+
+# キーをすべて大文字に変換
+update_keys(data.copy(), key=lambda k: k.upper())
+# data は変更されるので、コピーに対して操作する例
+# print(data) # -> {'FIRST_NAME': 'Alice', 'LAST_NAME': 'Smith', 'CONTACT_INFO': {'EMAIL_ADDRESS': 'alice@example.com'}}
+
+# キーをキャメルケースに変換 (dictknife.namingを利用)
+data_for_camel = {"first_name": "Bob", "user_age": 25, "address_details": {"street_name": "Main St"}}
+update_keys(data_for_camel, key=camelcase)
+print(data_for_camel)
+# 出力: {'firstName': 'Bob', 'userAge': 25, 'addressDetails': {'streetName': 'Main St'}}
+```
+
+### `update_keys` の派生関数
+
+`update_keys` を `functools.partial` で特殊化した、特定の命名規則にキーを一括変換する便利な関数が提供されています。これらはすべて **破壊的** です。
+
+*   `str_dict(d)`: キーを `str()` で変換 (主に型の一貫性のため)。
+*   `normalize_dict(d)`: キーを `dictknife.naming.normalize` で正規化。
+*   `snakecase_dict(d)`: キーを `dictknife.naming.snakecase` でスネークケースに変換。
+*   `camelcase_dict(d)`: キーを `dictknife.naming.camelcase` でキャメルケースに変換。
+*   `kebabcase_dict(d)`: キーを `dictknife.naming.kebabcase` でケバブケースに変換。
+*   `pascalcase_dict(d)`: キーを `dictknife.naming.pascalcase` でパスカルケースに変換。
+
+**実行例 (派生関数):**
+
+```python
+from dictknife.transform import snakecase_dict, camelcase_dict
+
+data_pascal = {"UserName": "Carol", "EmailAddress": "carol@example.com", "IsActive": True}
+snakecase_dict(data_pascal.copy()) # コピーに対して操作
+# data_pascal は {'user_name': 'Carol', 'email_address': 'carol@example.com', 'is_active': True} になる
+
+data_snake = {"user_name": "David", "email_address": "david@example.com", "is_active": False}
+camelcase_dict(data_snake) # 直接変更
+print(data_snake)
+# 出力: {'userName': 'David', 'emailAddress': 'david@example.com', 'isActive': False}
+```
+
+## `only_num(d)`
+
+辞書 `d` のうち、値が数値 ( `int` または `float`、ただし `bool` は除く) であるか、または数値として解釈できる文字列 (`isdigit()` が `True`) である要素のみを含む新しい辞書を返します。
+
+*   `d`: フィルタリング対象の辞書。
+
+**戻り値:** フィルタリングされた新しい辞書。
+
+**実行例:**
+
+```python
+from dictknife.transform import only_num
+
+data = {"name": "Test", "count": 10, "ratio": 0.75, "id_str": "12345", "active": True, "code": "A1"}
+numeric_data = only_num(data)
+print(numeric_data)
+# 出力 (キーの順序は不定):
+# {'count': 10, 'ratio': 0.75, 'id_str': '12345'}
+```
+
+## `only_str(d)`
+
+辞書 `d` のうち、値が文字列 (`str`) である要素のみを含む新しい辞書を返します。
+
+*   `d`: フィルタリング対象の辞書。
+
+**戻り値:** フィルタリングされた新しい辞書。
+
+**実行例:**
+
+```python
+from dictknife.transform import only_str
+
+data = {"name": "Test", "count": 10, "id_str": "12345", "active": True, "code": "A1"}
+string_data = only_str(data)
+print(string_data)
+# 出力 (キーの順序は不定):
+# {'name': 'Test', 'id_str': '12345', 'code': 'A1'}
+```
+
+## `shrink(d, *, max_length_of_string=100, cont_suffix="...", max_length_of_list=3, with_tail=False, mutable=False)`
+
+データ構造 `d` (辞書やリスト) 内の長い文字列や長いリストを指定された長さに縮小します。ログ出力やデータの概要表示などに便利です。
+
+*   `d`: 縮小対象のデータ構造。
+*   `max_length_of_string` (int, default: 100): 文字列の最大長。これを超えた文字列は切り詰められ、`cont_suffix` が付加されます。
+*   `cont_suffix` (str, default: `...`): 切り詰められた文字列の末尾に付加される接尾辞。
+*   `max_length_of_list` (int, default: 3): リストの最大長。これを超えたリストは先頭からこの長さまで切り詰められます。
+*   `with_tail` (bool, default: `False`): `True` の場合、リストが切り詰められる際に、先頭要素だけでなく末尾の要素も `max_length_of_list` 分だけ保持しようとします (現在は実装上、先頭に追加される形になっています)。
+*   `mutable` (bool, default: `False`): `True` の場合、元のデータ構造を直接変更 (破壊的変更) します。`False` の場合は新しいデータ構造を返します。
+
+**戻り値:** 縮小されたデータ構造 ( `mutable=False` の場合) または元のデータ構造への参照 ( `mutable=True` の場合)。
+
+**実行例:**
+
+```python
+from dictknife.transform import shrink
+
+data = {
+    "description": "This is a very long string that definitely exceeds the default maximum length of one hundred characters, so it should be truncated.",
+    "items": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    "config": {
+        "key": "another long string for testing purposes, let's see if this also gets cut off as expected by the shrink function."
+    },
+    "empty_list": [],
+    "short_string": "Hello"
+}
+
+shrunk_data_immutable = shrink(data)
+print("--- Immutable Shrink ---")
+print(shrunk_data_immutable)
+# 出力例 (description と config.key が切り詰められ、items が短縮される):
+# {
+#   'description': 'This is a very long string that definitely exceeds the default maximum length of one hundred charact...',
+#   'items': [1, 2, 3],
+#   'config': {
+#     'key': "another long string for testing purposes, let's see if this also gets cut off as expected by the sh..."
+#   },
+#   'empty_list': [],
+#   'short_string': 'Hello'
+# }
+
+shrunk_data_mutable = data.copy() # 元データを壊さないようにコピー
+shrink(shrunk_data_mutable, max_length_of_string=30, max_length_of_list=2, mutable=True)
+print("\n--- Mutable Shrink (max_string=30, max_list=2) ---")
+print(shrunk_data_mutable)
+# 出力例:
+# {
+#   'description': 'This is a very long string th...',
+#   'items': [1, 2],
+#   'config': {'key': "another long string for testi..."},
+#   'empty_list': [],
+#   'short_string': 'Hello'
+# }
+```
+```

--- a/docs/apidoc/walkers.md
+++ b/docs/apidoc/walkers.md
@@ -1,0 +1,150 @@
+```markdown
+# `dictknife.walkers`
+
+このモジュールは、ネストされた辞書やリストなどのデータ構造を柔軟に探索・走査するためのクラスを提供します。中心となるのは `DictWalker` クラスで、探索条件やコンテキスト、結果の処理方法をカスタマイズできます。
+
+## `DictWalker` クラス
+
+ネストされた辞書やリストを再帰的に探索し、指定された条件 (`qs`) にマッチする要素を見つけ出すためのイテレータを提供します。
+
+**エイリアス:** `LooseDictWalkingIterator` (後方互換性のためのエイリアスです。新しいコードでは `DictWalker` の使用を推奨します。)
+
+### `__init__(self, qs, handler=None, context_factory=None)`
+
+*   `qs`: クエリのシーケンス (リストやタプル)。探索するパスの各階層に対する条件を指定します。
+    *   各要素は、リテラル値 (キー名やインデックスと直接比較) や、`dictknife.operators` モジュールで定義された演算子 (`Regexp`, `Any`, `Not`, `Or`, `And` など) のインスタンスです。
+    *   例えば、`["users", ANY, "name"]` は、トップレベルの `users` キー -> 任意のキー/インデックス -> `name` キー、というパスを探索します。
+*   `handler=None`: マッチした要素が見つかった場合に、その要素をどのように処理するかを定義するハンドラオブジェクト。
+    *   デフォルトは `ContainerHandler` インスタンスです。
+    *   `DataHandler` やカスタムハンドラを指定できます。
+*   `context_factory=None`: 探索中のコンテキスト情報を管理するオブジェクトを生成するファクトリ関数またはクラス。
+    *   デフォルトは `PathContext` です。
+    *   `SimpleContext`, `RecPathContext` やカスタムコンテキストファクトリを指定できます。
+
+### `walk(self, d, qs=None, depth=-1, ctx=None)`
+
+データ構造 `d` を探索し、条件にマッチした要素をyieldするジェネレータメソッドです。
+
+*   `d`: 探索対象の辞書またはリスト。
+*   `qs=None`: `__init__` で指定したものと異なるクエリシーケンスを使用する場合に指定。デフォルトは `__init__` で指定された `qs` を使用。
+*   `depth=-1`: 探索する最大の深さ。
+    *   `-1` (デフォルト): 深さ制限なし。
+    *   `0`: 何も探索しません。
+    *   `1`: トップレベルのみ探索。
+*   `ctx=None`: `__init__` で指定したものと異なるコンテキストオブジェクトを初期状態で使用する場合に指定。
+
+**戻り値 (yield):**
+ハンドラ (`self.handler`) とコンテキスト (`ctx`) の組み合わせによって、yieldされる値の形式が決まります。
+デフォルトの `PathContext` と `ContainerHandler` の組み合わせでは、`on_found` メソッドは `ctx(walker, self.handler.identity, d)` を呼び出し、`PathContext` は `fn(self.path, value)` を実行するので、`(path_list, container_dict)` のようなタプルがyieldされることが期待されます。ここで `path_list` はマッチした要素までのパス、`container_dict` はマッチしたキーを含むコンテナです。
+
+**エイリアス:** `iterate` (後方互換性のためのエイリアスです。)
+
+**実行例:**
+
+```python
+from dictknife.walkers import DictWalker
+from dictknife.operators import ANY, Regexp
+
+data = {
+    "users": [
+        {"id": 1, "name": "Alice", "settings": {"theme": "dark", "active": True}},
+        {"id": 2, "name": "Bob", "email": "bob@example.com"},
+        {"id": 3, "name": "Charlie", "settings": {"theme": "light", "active": False}},
+    ],
+    "config": {"version": "1.0", "debug_mode": False}
+}
+
+# 例1: 全てのユーザーの名前を取得
+# qs: "users" キー -> 任意インデックス -> "name" キー
+walker_names = DictWalker(["users", ANY, "name"])
+for path, name_value_container in walker_names.walk(data):
+    # デフォルトハンドラ(ContainerHandler)はキーを含むコンテナを返す
+    # path は ['users', (インデックス), 'name']
+    # name_value_container は {'name': 'xxx'} のような辞書
+    print(f"Path: {path}, Value: {name_value_container[path[-1]]}")
+# 出力例:
+# Path: ['users', 0, 'name'], Value: Alice
+# Path: ['users', 1, 'name'], Value: Bob
+# Path: ['users', 2, 'name'], Value: Charlie
+
+# 例2: 'settings' の中の 'theme' の値を取得 (DataHandlerを使用)
+from dictknife.walkers import DataHandler
+walker_themes = DictWalker(
+    ["users", ANY, "settings", "theme"],
+    handler=DataHandler()
+)
+for path, theme_value in walker_themes.walk(data):
+    # DataHandler は実際の値を返す
+    # path は ['users', (インデックス), 'settings', 'theme']
+    print(f"Path: {path}, Theme: {theme_value}")
+# 出力例:
+# Path: ['users', 0, 'settings', 'theme'], Theme: dark
+# Path: ['users', 2, 'settings', 'theme'], Theme: light
+
+# 例3: 正規表現でキーに 'id' を含むものを探す (深さ制限あり)
+walker_ids = DictWalker([Regexp(r"id")], handler=DataHandler())
+for path, id_value in walker_ids.walk(data, depth=2): # usersリスト内のidは深さ3なのでマッチしない
+    print(f"Path: {path}, ID Value: {id_value}")
+# "users" キー自体は depth=1、その中の辞書は depth=2、辞書内の "id" は depth=3
+# この例では何も出力されないか、あるいは意図しないトップレベルのキーにマッチする可能性がある。
+# クエリを ["users", ANY, Regexp(r"id")] のように具体的にするか、depth調整が必要。
+
+# より正確なID探索の例
+walker_user_ids = DictWalker(["users", ANY, "id"], handler=DataHandler())
+for path, user_id in walker_user_ids.walk(data):
+    print(f"Path: {path}, User ID: {user_id}")
+# 出力例:
+# Path: ['users', 0, 'id'], User ID: 1
+# Path: ['users', 1, 'id'], User ID: 2
+# Path: ['users', 2, 'id'], User ID: 3
+```
+
+### `on_found(self, ctx, d, k)`
+
+内部メソッド。条件に完全にマッチした際 (`qs` の条件を全て満たしたパスが見つかった時) に呼び出され、`self.handler` を介して結果をyieldします。
+
+### `create_context(self, ctx=None)`
+
+内部メソッド。探索のためのコンテキストオブジェクトを生成または返します。
+
+## コンテキストクラス
+
+探索中に現在のパスや状態を管理します。`DictWalker` の `context_factory` に指定します。
+
+### `SimpleContext`
+
+最も基本的なコンテキスト。パス情報は保持しません。
+`__call__(self, walker, fn, value)` は `fn(value)` を呼び出します。
+
+### `PathContext` (デフォルト)
+
+探索中の現在のパス (キー/インデックスのリスト) を `self.path` に保持します。
+`__call__(self, walker, fn, value)` は `fn(self.path, value)` を呼び出します。
+
+### `RecPathContext`
+
+`PathContext` を継承。
+`__call__(self, walker, fn, value)` は `fn(walker, self.path, value)` を呼び出し、ウォーカー自身も渡します。
+
+## ハンドラクラス
+
+`DictWalker` が条件にマッチする要素を見つけたときに、その要素をどのように処理 (yield) するかを定義します。`DictWalker` の `handler` に指定します。
+
+### `ContainerHandler` (デフォルト)
+
+マッチしたキー `k` を含むコンテナ `d` を、コンテキストを通じて処理します。
+デフォルトの `PathContext` と組み合わせると、`(path_to_k, d)` のような形式で結果が渡されることが多いです (実際には `ctx(walker, self.identity, d)` が呼び出され、`PathContext` は `self.identity(path, d)` を呼び、結果として `(path, d)` が返る)。 `d[k]` で実際の値にアクセスできます。
+
+### `DataHandler`
+
+マッチした実際のデータ `d[k]` を、コンテキストを通じて処理します。
+デフォルトの `PathContext` と組み合わせると、`(path_to_k, d[k])` のような形式で結果が渡されることが多いです (実際には `ctx(walker, self.identity, d[k])` が呼び出され、`PathContext` は `self.identity(path, d[k])` を呼び、結果として `(path, d[k])` が返る)。
+
+---
+
+**利用上の注意点:**
+`DictWalker` の `walk` (または `iterate`) メソッドがyieldする値の具体的な形式は、`context_factory` と `handler` の組み合わせによって変わります。
+デフォルトの `PathContext` と `ContainerHandler` の場合、`for path, container in walker.walk(data): ...` のように受け取り、`container[path[-1]]` で値にアクセスできます。
+`PathContext` と `DataHandler` の場合は `for path, value in walker.walk(data): ...` のように直接値を受け取れます。
+ドキュメントの実行例も参照し、使用するコンテキストとハンドラに応じて適切に結果を処理してください。
+```


### PR DESCRIPTION
Generated initial Markdown API documentation for the following core dictknife modules and commands:
- dictknife.accessing
- dictknife.deepequal
- dictknife.deepmerge
- dictknife.diff (and diff.rows)
- dictknife.guessing
- dictknife.loading (and related format loaders)
- dictknife commands (cat, transform, diff, shape, shrink, mkdict)
- jsonknife commands (cut, select, bundle, separate, examples)
- swaggerknife commands (tojsonschema, json2swagger, merge, flatten)

Also included documentation for:
- dictknife.cliutils.extraarguments
- dictknife.jsonknife submodules (accessor, bundler, expander, etc.)
- dictknife.swaggerknife submodules (flatten, json2swagger, migration)

The documentation is in Japanese as per the initial phase of generation. Further review and translation for other modules are marked as TODO.