### PR TITLE
docs: dictknife モジュールのAPIドキュメントを作成/更新

### DIFF
--- a/docs/apidoc/langhelpers.md
+++ b/docs/apidoc/langhelpers.md
@@ -1,0 +1,156 @@
+```markdown
+# `dictknife.langhelpers`
+
+このモジュールは、`dictknife` ライブラリ全体で利用される可能性のある、さまざまな補助関数やクラスを提供します。文字列操作、プロパティのキャッシュ、JSON Pointerの変換などが含まれます。
+
+## `make_dict`
+
+Pythonのバージョンに応じて、`dict` (Python 3.6以降) または `collections.OrderedDict` (それ以前) を返します。これは、辞書のキーの順序を保持するための互換性レイヤーとして機能します。
+
+**利用例:**
+
+```python
+from dictknife.langhelpers import make_dict
+
+# Python 3.6 以降では通常の dict と同様
+my_dict = make_dict()
+my_dict["b"] = 1
+my_dict["a"] = 2
+print(list(my_dict.keys())) # 環境により ['b', 'a'] または ['a', 'b'] (3.7+なら挿入順)
+
+# Python 3.5 以前では OrderedDict と同様
+# (OrderedDict の場合、キーは挿入順に保持される)
+```
+*注: この `make_dict` は `dictknife.accessing.Accessor` など、他のモジュールでデフォルトの辞書ファクトリとして内部的に利用されることがあります。*
+
+## `pairsplit(s, sep)`
+
+文字列 `s` を、最初の区切り文字 `sep` で2つの部分に分割します。区切り文字が見つからない場合、2つ目の要素は空文字列になります。
+
+*   `s`: 分割する文字列。
+*   `sep`: 区切り文字。
+
+**戻り値:** `(文字列1, 文字列2)` のタプル。
+
+**実行例:**
+
+```python
+from dictknife.langhelpers import pairsplit
+
+result1 = pairsplit("key=value", "=")
+# result1 is ('key', 'value')
+
+result2 = pairsplit("key:value:another", ":")
+# result2 is ('key', 'value:another')
+
+result3 = pairsplit("keyonly", "=")
+# result3 is ('keyonly', '')
+```
+
+## `pairrsplit(s, sep)`
+
+文字列 `s` を、最後の区切り文字 `sep` で2つの部分に分割します。区切り文字が見つからない場合、2つ目の要素は空文字列になります。`rsplit` の動作に似ています。
+
+*   `s`: 分割する文字列。
+*   `sep`: 区切り文字。
+
+**戻り値:** `(文字列1, 文字列2)` のタプル。
+
+**実行例:**
+
+```python
+from dictknife.langhelpers import pairrsplit
+
+result1 = pairrsplit("key=value=another", "=")
+# result1 is ('key=value', 'another')
+
+result2 = pairrsplit("one:two", ":")
+# result2 is ('one', 'two')
+
+result3 = pairrsplit("keyonly", "=")
+# result3 is ('keyonly', '')
+```
+
+## `reify` クラス
+
+プロパティをキャッシュするためのデコレータクラスです。一度計算されたプロパティの値はインスタンスに保存され、次回以降のアクセスでは再計算せずに保存された値を返します。
+これは [pyramid](https://trypyramid.com/) フレームワークから着想を得たものです。
+
+**利用例:**
+
+```python
+from dictknife.langhelpers import reify
+
+class MyClass:
+    def __init__(self, data):
+        self._data = data
+        self._compute_count = 0
+
+    @reify
+    def expensive_property(self):
+        print("Computing expensive_property...")
+        self._compute_count += 1
+        # 何か重い計算をシミュレート
+        return sum(self._data)
+
+obj = MyClass([1, 2, 3, 4, 5])
+
+print(obj.expensive_property)  # "Computing expensive_property..." が出力され、15 が表示される
+print(f"Compute count: {obj._compute_count}") # 1
+
+print(obj.expensive_property)  # 計算は行われず、キャッシュされた 15 が表示される
+print(f"Compute count: {obj._compute_count}") # 1 (増えない)
+
+# プロパティはインスタンスの属性として保存される
+print(obj.__dict__["expensive_property"]) # 15
+```
+
+## `as_jsonpointer(k)`
+
+与えられたキー `k` (通常は文字列または整数) をJSON Pointerのフラグメント識別子形式に変換します。具体的には、`~` を `~0` に、`/` を `~1` にエスケープします。
+
+*   `k`: 変換するキー。文字列に変換されて処理されます。
+
+**戻り値:** JSON Pointer形式の文字列。
+
+**実行例:**
+
+```python
+from dictknife.langhelpers import as_jsonpointer
+
+ptr1 = as_jsonpointer("foo")
+# ptr1 is "foo"
+
+ptr2 = as_jsonpointer("foo/bar")
+# ptr2 is "foo~1bar"
+
+ptr3 = as_jsonpointer("foo~bar")
+# ptr3 is "foo~0bar"
+
+ptr4 = as_jsonpointer(0) # 数値も扱える
+# ptr4 is "0"
+```
+
+## `as_path_node(ref)`
+
+JSON Pointerのフラグメント識別子形式の文字列 `ref` を、元のキーの形式に戻します。`as_jsonpointer` の逆操作に相当し、`~1` を `/` に、`~0` を `~` にアンエスケープします。
+
+*   `ref`: JSON Pointer形式の文字列。
+
+**戻り値:** 元のキー形式の文字列。
+
+**実行例:**
+
+```python
+from dictknife.langhelpers import as_path_node
+
+node1 = as_path_node("foo")
+# node1 is "foo"
+
+node2 = as_path_node("foo~1bar")
+# node2 is "foo/bar"
+
+node3 = as_path_node("foo~0bar")
+# node3 is "foo~bar"
+```
+```

--- a/docs/apidoc/loading_modification.md
+++ b/docs/apidoc/loading_modification.md
@@ -1,0 +1,183 @@
+```markdown
+# `dictknife.loading.modification`
+
+このパッケージは、`dictknife.loading` のローダー ( `Loader` ) やダンパー ( `Dumper` ) のデフォルトの挙動を動的に変更するためのモジュール群を提供します。各モジュールは `setup(dispatcher)` 関数を公開しており、これを呼び出すことでディスパッチャの特定の動作が変更されます。
+
+通常、これらの modification は `dictknife` のコマンドラインインターフェースで特定のオプションが指定された際に内部的に適用されますが、ライブラリとして `dictknife.loading` を直接利用する際にも個別に適用することが可能です。
+
+## パッケージ内のヘルパー関数
+
+`dictknife.loading.modification` パッケージの `__init__.py` では、以下のヘルパー関数が定義されています。これらは主に各 modification モジュール内部で使用されます。
+
+*   `is_used(dispatcher, name)`: 指定された `name` の modification が既に `dispatcher` に適用済みかどうかを確認します。
+*   `use(dispatcher, name)`: 指定された `name` の modification を `dispatcher` に適用済みとして記録します。
+
+## 利用可能な Modification モジュール
+
+### `dictknife.loading.modification.compact`
+
+JSON形式で出力する際に、インデントなしのコンパクトな形式で出力するように変更します。
+
+*   **関数:** `setup(dispatcher)`
+*   **対象:** ダンパー (`dispatcher.dumper`)
+*   **変更内容:** `dispatcher.dumper.fn_map["json"]` のダンプ関数を、`indent=None` で呼び出すように変更します。
+
+**使用例:**
+
+```python
+from dictknife.loading import get_dumper
+from dictknife.loading.modification import compact
+import sys
+
+dumper = get_dumper("json") # 通常のJSONダンパーを取得
+data = {"name": "example", "version": 1, "items": [1, 2, 3]}
+
+print("--- Default JSON dump ---")
+dumper.dump(data, sys.stdout)
+# 出力例 (インデントあり):
+# {
+#   "items": [
+#     1,
+#     2,
+#     3
+#   ],
+#   "name": "example",
+#   "version": 1
+# }
+
+compact.setup(dumper) # compact modification を適用
+
+print("\n--- Compact JSON dump ---")
+dumper.dump(data, sys.stdout)
+# 出力例 (インデントなし):
+# {"items": [1, 2, 3], "name": "example", "version": 1}
+```
+
+### `dictknife.loading.modification.flatten`
+
+データを出力する際に、事前に辞書をフラット化 (ネストした辞書をキーを連結して一段階に展開) するように変更します。
+
+*   **関数:** `setup(dispatcher)`
+*   **対象:** ダンパー (`dispatcher.dumper`)
+*   **変更内容:** `dispatcher.dumper.fn_map` に登録されている全てのダンプ関数をラップし、ダンプ対象のデータを `dictknife.transform.flatten()` で前処理するようにします。
+
+**使用例:**
+
+```python
+from dictknife.loading import get_dumper
+from dictknife.loading.modification import flatten
+import sys
+
+dumper = get_dumper("json")
+data = {"user": {"name": "Alice", "age": 30}, "status": "active"}
+
+print("--- Default JSON dump (nested) ---")
+dumper.dump(data, sys.stdout)
+# 出力例:
+# {
+#   "status": "active",
+#   "user": {
+#     "age": 30,
+#     "name": "Alice"
+#   }
+# }
+
+flatten.setup(dumper) # flatten modification を適用
+
+print("\n--- Flattened JSON dump ---")
+dumper.dump(data, sys.stdout)
+# 出力例:
+# {
+#   "status": "active",
+#   "user.age": 30,
+#   "user.name": "Alice"
+# }
+```
+
+### `dictknife.loading.modification.unescape_unicode`
+
+入力ストリームからデータを読み込む際に、Unicodeエスケープシーケンス (`\uXXXX` 形式) をデコードするように変更します。
+
+*   **関数:** `setup(dispatcher)`
+*   **対象:** ローダー (`dispatcher.loader`)
+*   **変更内容:** `dispatcher.loader.fn_map` に登録されている全てのロード関数をラップし、入力ストリームから読み取った文字列に対して `.encode("utf-8").decode("unicode-escape")` を適用し、前後のクォートを除去する前処理を行います。
+
+**使用例:**
+
+```python
+from dictknife.loading import get_loader
+from dictknife.loading.modification import unescape_unicode
+from io import StringIO
+
+loader = get_loader("json") # JSONローダーを取得
+
+# UnicodeエスケープされたJSON文字列
+escaped_json_str = '"{\\"name\\": \\"\\u30c6\\u30b9\\u30c8\\u540d\\", \\"value\\": \\"\\u0041\\u0042\\u0043\\"}"' # クォートで囲まれた文字列中のJSON
+
+# modification なしの場合 (入力が文字列リテラルのため、Pythonが先にデコードしてしまう場合があるので注意)
+# この例ではStringIOでラップすることで、 modification の効果を明確にする
+# loader.load(StringIO(escaped_json_str)) -> 通常はエラーになるか、エスケープされたままの文字列として解釈される
+
+unescape_unicode.setup(loader) # unescape_unicode modification を適用
+
+data = loader.load(StringIO(escaped_json_str))
+print(data)
+# 出力例:
+# {'name': 'テスト名', 'value': 'ABC'}
+```
+*注意: `unescape_unicode` は入力文字列全体を一度読み込んで処理します。非常に大きなストリームには適さない場合があります。*
+
+### `dictknife.loading.modification.unescape_url`
+
+入力ストリームからデータを読み込む際に、URLエンコード (パーセントエンコーディング) された文字列をデコードするように変更します。
+
+*   **関数:** `setup(dispatcher)`
+*   **対象:** ローダー (`dispatcher.loader`)
+*   **変更内容:** `dispatcher.loader.fn_map` に登録されている全てのロード関数をラップし、入力ストリームから読み取った文字列に対して `urllib.parse.unquote_plus()` を適用し、前後のクォートを除去する前処理を行います。
+
+**使用例:**
+
+```python
+from dictknife.loading import get_loader
+from dictknife.loading.modification import unescape_url
+from io import StringIO
+
+loader = get_loader("json") # JSONローダーを取得 (他の形式でも動作しうる)
+
+# URLエンコードされたJSON文字列 (実際にはJSONである必要はないが、loaderが対応する形式にデコードされる)
+url_encoded_str = '"name=%E3%83%86%E3%82%B9%E3%83%88%20%E5%90%8D&value=A%2BB%20C"' # クォートで囲まれたURLエンコード文字列
+
+# modification なしの場合
+# loader.load(StringIO(url_encoded_str)) -> URLエンコードされたままの文字列として解釈される
+
+unescape_url.setup(loader) # unescape_url modification を適用
+
+# この modification は文字列をデコードするだけなので、
+# デコード後の文字列がloaderの期待する形式 (この場合はJSON) である必要がある。
+# この例では、デコード後がJSONではないため、JSONローダーではエラーになる。
+# ここではデコード処理そのものに焦点を当てる。
+# 実際の使用では、デコード後の文字列が適切な形式になるようにする。
+
+# 例として、デコード後の文字列を取得する処理をシミュレート
+# (実際にはloaderがこの処理を行う)
+from urllib.parse import unquote_plus
+temp_stream = StringIO(url_encoded_str)
+raw_content = temp_stream.read()
+if raw_content.startswith('"') and raw_content.endswith('"'): # クォート除去のシミュレーション
+    raw_content = raw_content[1:-1]
+decoded_string = unquote_plus(raw_content)
+print(f"Decoded string: {decoded_string}")
+# 出力例:
+# Decoded string: name=テスト 名&value=A+B C
+
+# loader に渡すのは、デコード後にJSONとしてパース可能な文字列である必要がある。
+# 例えば、URLエンコードされたJSONペイロードの場合:
+url_encoded_json = '"%7B%22name%22%3A%20%22%E3%83%86%E3%82%B9%E3%83%88%E5%90%8D%22%2C%20%22value%22%3A%20%22A%2BB%20C%22%7D"'
+data = loader.load(StringIO(url_encoded_json))
+print(data)
+# 出力例:
+# {'name': 'テスト名', 'value': 'A+B C'}
+
+```
+*注意: `unescape_url` は入力文字列全体を一度読み込んで処理します。非常に大きなストリームには適さない場合があります。*
+```

--- a/docs/apidoc/mkdict.md
+++ b/docs/apidoc/mkdict.md
@@ -1,0 +1,128 @@
+```markdown
+# `dictknife.mkdict`
+
+このモジュールは、特定のミニ言語構文で記述された一行の文字列から、Pythonの辞書または辞書のリストを生成する機能を提供します。コマンドラインツール `dictknife mkdict` のコアロジックでもあります。
+
+## `mkdict(line, *, separator="/", delimiter=";", accessor=_AccessorSupportList(make_dict), guess=guess, shared=None)`
+
+与えられた文字列 `line` を解析し、辞書または辞書のリストを構築して返します。
+
+*   `line` (str): 解析対象の文字列。独自のミニ言語構文で記述されます。
+*   `separator` (str, default: `/`): ネストされたキーを指定する際の区切り文字。例えば `parent/child` は `{"parent": {"child": ...}}` のように解釈されます。
+*   `delimiter` (str, default: `;`): 複数の辞書エントリを区切るための文字。この文字で区切られた場合、結果は辞書のリストになります。
+*   `accessor` (object, default: `_AccessorSupportList` instance): 内部的にキーと値の割り当てを行うアクセサオブジェクト。デフォルトの `_AccessorSupportList` は、パスの指定に応じてリストも適切に扱えるように拡張されたアクセサです。
+*   `guess` (callable, default: `dictknife.guessing.guess`): 値の型を推論する関数。文字列 "true", "false", "null", "10", "3.14" などが適切なPythonの型 (bool, None, int, float) に変換されます。
+*   `shared` (dict, default: `None`): 複数の `mkdict` 呼び出しや、内部のブロック間で共有される変数を格納するための辞書。`None` の場合は呼び出しごとに独立した変空間が使われます。
+
+**戻り値:** 生成された辞書、または辞書のリスト。
+
+### ミニ言語の主要構文
+
+`mkdict` が解釈する文字列 `line` は、以下のルールに基づいた構文を持ちます。
+
+1.  **キーと値のペア:**
+    スペース区切りで `キー 値` のように指定します。
+    例: `name Alice age 30` -> `{'name': 'Alice', 'age': 30}`
+
+2.  **ネストしたキー (separator):**
+    `separator` (デフォルト `/`) を使ってキーをネストできます。
+    例: `user/name Alice user/contact/email alice@example.com`
+    -> `{'user': {'name': 'Alice', 'contact': {'email': 'alice@example.com'}}}`
+
+3.  **複数の辞書 (delimiter):**
+    `delimiter` (デフォルト `;`) を使うと、複数の辞書からなるリストを生成できます。
+    例: `id 1 ; id 2` -> `[{'id': 1}, {'id': 2}]`
+
+4.  **値のグループ化 (ブロック `{}`):**
+    `{` と `}` で囲むことで、値をグループ化できます。これは主にネストした辞書を値として割り当てる際に使います。
+    例: `user { name Alice age 30 } status active`
+    -> `{'user': {'name': 'Alice', 'age': 30}, 'status': 'active'}`
+
+5.  **変数定義 (`@`):**
+    `@変数名 値` または `@変数名/ネストキー 値` で変数を定義できます。変数は内部の共有空間 (`shared` または `variables`) に保存されます。
+    例: `@default_user { name Unknown active false }`
+
+6.  **変数参照 (`&`):**
+    `&変数名` または `&変数名/ネストキー` で定義済みの変数を参照できます。
+    例: `user1 &default_user user2 { name Alice }` (user2 は default_user を部分的に上書き)
+
+7.  **リストの作成:**
+    キーの末尾に `separator` を付ける (例: `items/`) か、パスの途中で空のキー (`//`) や数値インデックスを指定することでリストやリスト内の要素を操作できます。
+    *   `items/ value1 items/ value2` -> `{'items': ['value1', 'value2']}`
+    *   `items//name valueA items//name valueB` -> `{'items': [{'name': 'valueA'}, {'name': 'valueB'}]}`
+    *   `items/0/name valueA items/1/name valueB` -> `{'items': [{'name': 'valueA'}, {'name': 'valueB'}]}`
+    *   `items/-1/property value` は、現在のリストの最後の要素に `property` を追加/更新します。
+
+8.  **エスケープ:**
+    `{{`, `}}`, `&&`, `@@` はそれぞれ `{`, `}`, `&`, `@` という文字そのものとして扱われます。
+
+9.  **値の型推論:**
+    値は `guess` 関数によって型が推論されます。
+    `"true"` -> `True`, `"10"` -> `10`, `"3.14"` -> `3.14`, `"null"` -> `None`。
+
+**実行例:**
+
+```python
+from dictknife.mkdict import mkdict
+from dictknife.langhelpers import make_dict # OrderedDictのため (Python 3.6+では不要かも)
+from dictknife.guessing import guess as default_guess
+from dictknife.mkdict import _AccessorSupportList
+
+# カスタムアクセサやguess関数も指定可能だが、通常はデフォルトで十分
+custom_accessor = _AccessorSupportList(make_dict=make_dict)
+
+# 基本的な例
+data1 = mkdict("name Alice age 30 active true")
+print(data1)
+# 出力: {'name': 'Alice', 'age': 30, 'active': True}
+
+# ネストとリスト
+data2 = mkdict("user/name Bob user/tags/ tag1 user/tags/ tag2 score 100.5")
+print(data2)
+# 出力: {'user': {'name': 'Bob', 'tags': ['tag1', 'tag2']}, 'score': 100.5}
+
+# デリミタを使ったリスト
+data3 = mkdict("type A value 1 ; type B value 2 ; type C value 3")
+print(data3)
+# 出力: [{'type': 'A', 'value': 1}, {'type': 'B', 'value': 2}, {'type': 'C', 'value': 3}]
+
+# ブロックと変数
+line4 = "@common_settings { debug false port 8080 } server1 { host localhost } server1/settings &common_settings ; server2 { host 192.168.1.100 } server2/settings &common_settings server2/settings/port 9000"
+data4 = mkdict(line4)
+print(data4)
+# 出力:
+# [
+#   {'server1': {'host': 'localhost', 'settings': {'debug': False, 'port': 8080}}},
+#   {'server2': {'host': '192.168.1.100', 'settings': {'debug': False, 'port': 9000}}}
+# ]
+
+# 共有変数を使った例
+shared_vars = {}
+mkdict("@shared_val initial", shared=shared_vars)
+data5_part1 = mkdict("item1 &shared_val", shared=shared_vars)
+mkdict("@shared_val updated", shared=shared_vars) # shared_vars内の値を更新
+data5_part2 = mkdict("item2 &shared_val", shared=shared_vars)
+
+print(f"Shared vars: {shared_vars}")
+print(f"Data5 Part1: {data5_part1}")
+print(f"Data5 Part2: {data5_part2}")
+# 出力:
+# Shared vars: {'shared_val': 'updated'}
+# Data5 Part1: {'item1': 'initial'}
+# Data5 Part2: {'item2': 'updated'}
+
+# リスト内の要素への詳細なアクセス
+line6 = "items//id 1 items/-1/name A items//id 2 items/-1/name B items/0/status active"
+data6 = mkdict(line6)
+print(data6)
+# 出力: {'items': [{'id': 1, 'name': 'A', 'status': 'active'}, {'id': 2, 'name': 'B'}]}
+```
+
+### 内部関数とクラス
+
+*   `_mkdict(...)`: `mkdict` のコアロジックを実装する再帰関数。
+*   `tokenize(line)`: `shlex` をベースにしたカスタムトークナイザ。入力行をミニ言語のトークンに分割します。
+*   `_AccessorSupportList`: `dictknife.accessing.Accessor` を継承し、リストのインデックス (`/0/`, `//`, `/-1/`) を特別扱いしてリスト操作をサポートする内部クラス。
+
+これらの内部コンポーネントは通常、`mkdict` 関数を通じて間接的に利用されます。
+```

--- a/docs/apidoc/naming.md
+++ b/docs/apidoc/naming.md
@@ -1,0 +1,222 @@
+```markdown
+# `dictknife.naming`
+
+このモジュールは、文字列の命名規則を変換するための関数群を提供します。例えば、スネークケース、ケバブケース、キャメルケース、パスカルケース間の変換や、文字列の正規化などを行います。
+
+## `normalize(name, ignore_rx=re.compile("[^0-9a-zA-Z_]+"))`
+
+与えられた `name` 文字列を正規化します。デフォルトでは、ハイフン `-` をアンダースコア `_` に置換した後、英数字とアンダースコア以外の文字をすべて除去します。
+
+*   `name`: 正規化する文字列。
+*   `ignore_rx`: 除去する文字パターンを指定する正規表現オブジェクト。デフォルトは `[^0-9a-zA-Z_]+`。
+
+**戻り値:** 正規化された文字列。
+
+**実行例:**
+
+```python
+from dictknife.naming import normalize
+
+name1 = normalize("My-Variable Name 123")
+# name1 is "My_VariableName_123"
+
+name2 = normalize("foo-bar*baz")
+# name2 is "foo_barbaz"
+
+# カスタム正規表現でアンダースコアも除去する例
+import re
+name3 = normalize("My_Variable_Name", ignore_rx=re.compile("[^0-9a-zA-Z]+"))
+# name3 is "MyVariableName"
+```
+
+## `snakecase(name, *, rx0=..., rx1=..., separator="_", other="-")`
+
+文字列 `name` をスネークケース (例: `snake_case_example`) に変換します。
+内部的に正規表現 `rx0` と `rx1` を使用して大文字と小文字の境界を検出し、`separator` (デフォルトは `_`) で区切ります。また、`other` (デフォルトは `-`) で指定された文字も `separator` に置換します。
+
+*   `name`: 変換する文字列。
+*   `separator`: 単語区切りに使用する文字。デフォルトは `_`。
+*   `other`: `separator` に置換される追加の文字。デフォルトは `-`。
+
+**戻り値:** スネークケースに変換された文字列。
+
+**実行例:**
+
+```python
+from dictknife.naming import snakecase
+
+s1 = snakecase("CamelCaseName")
+# s1 is "camel_case_name"
+
+s2 = snakecase("PascalCaseName")
+# s2 is "pascal_case_name"
+
+s3 = snakecase("already_snake_case")
+# s3 is "already_snake_case"
+
+s4 = snakecase("kebab-case-name")
+# s4 is "kebab_case_name"
+
+s5 = snakecase("HTTPResponseCode")
+# s5 is "http_response_code"
+
+s6 = snakecase("ABcDEF") # 連続する大文字の扱い
+# s6 is "a_bc_def"
+```
+
+## `kebabcase(name, *, rx0=..., rx1=..., separator="-", other="_")`
+
+文字列 `name` をケバブケース (例: `kebab-case-example`) に変換します。
+`snakecase` と同様のロジックですが、デフォルトの `separator` が `-`、`other` が `_` になります。
+
+*   `name`: 変換する文字列。
+*   `separator`: 単語区切りに使用する文字。デフォルトは `-`。
+*   `other`: `separator` に置換される追加の文字。デフォルトは `_`。
+
+**戻り値:** ケバブケースに変換された文字列。
+
+**実行例:**
+
+```python
+from dictknife.naming import kebabcase
+
+k1 = kebabcase("CamelCaseName")
+# k1 is "camel-case-name"
+
+k2 = kebabcase("PascalCaseName")
+# k2 is "pascal-case-name"
+
+k3 = kebabcase("already-kebab-case")
+# k3 is "already-kebab-case"
+
+k4 = kebabcase("snake_case_name")
+# k4 is "snake-case-name"
+
+k5 = kebabcase("HTTPResponseCode")
+# k5 is "http-response-code"
+```
+
+## `camelcase(name, *, soft=True)`
+
+文字列 `name` をキャメルケース (例: `camelCaseExample`) に変換します。
+
+*   `name`: 変換する文字列。
+*   `soft=True` (デフォルト): もし `name` の最初の文字が大文字の場合、パスカルケース (`PascalCaseExample`) として扱います。`False` の場合は、最初の文字が小文字になるように強制します。
+
+**戻り値:** キャメルケースまたはパスカルケースに変換された文字列。
+
+**実行例:**
+
+```python
+from dictknife.naming import camelcase
+
+c1 = camelcase("snake_case_name")
+# c1 is "snakeCaseName"
+
+c2 = camelcase("kebab-case-name")
+# c2 is "kebabCaseName"
+
+c3 = camelcase("PascalCaseName") # soft=True なので PascalCase のまま
+# c3 is "PascalCaseName"
+
+c4 = camelcase("PascalCaseName", soft=False) # soft=False なので先頭小文字
+# c4 is "pascalCaseName"
+
+c5 = camelcase("alreadyCamelCase")
+# c5 is "alreadyCamelCase"
+
+c6 = camelcase("Title Case Name")
+# c6 is "TitleCaseName" (pascalcase経由)
+```
+
+## `pascalcase(name, rx=re.compile(r"[\-_ ]"))`
+
+文字列 `name` をパスカルケース (例: `PascalCaseExample`) に変換します。デフォルトでは、アンダースコア `_`、ハイフン `-`、スペース ` ` を区切り文字として単語に分割し、各単語の先頭を大文字にして結合します。
+
+*   `name`: 変換する文字列。
+*   `rx`: 単語の区切り文字を定義する正規表現。デフォルトは `[\-_ ]`。
+
+**戻り値:** パスカルケースに変換された文字列。
+
+**実行例:**
+
+```python
+from dictknife.naming import pascalcase
+
+p1 = pascalcase("snake_case_name")
+# p1 is "SnakeCaseName"
+
+p2 = pascalcase("kebab-case-name")
+# p2 is "KebabCaseName"
+
+p3 = pascalcase("camelCaseName") # 先頭も大文字になる
+# p3 is "CamelCaseName"
+
+p4 = pascalcase("a_b_c")
+# p4 is "ABC"
+
+p5 = pascalcase("alreadyPascalCase")
+# p5 is "AlreadyPascalCase" (最初の単語として扱われる)
+
+p6 = pascalcase("title case words")
+# p6 is "TitleCaseWords"
+```
+
+## `titleize(name)`
+
+文字列 `name` の最初の文字を大文字にし、残りの文字はそのままにします (いわゆるタイトルケースとは異なり、単語の先頭を全て大文字化するわけではありません)。
+
+*   `name`: 変換する文字列。
+
+**戻り値:** 最初の文字が大文字化された文字列。`name` が空の場合は空文字列を返します。
+
+**実行例:**
+
+```python
+from dictknife.naming import titleize
+
+t1 = titleize("hello")
+# t1 is "Hello"
+
+t2 = titleize("world")
+# t2 is "World"
+
+t3 = titleize("AlreadyTitled")
+# t3 is "AlreadyTitled"
+
+t4 = titleize("")
+# t4 is ""
+
+t5 = titleize("1st")
+# t5 is "1st" (最初の文字が非アルファベットの場合、そのまま)
+```
+
+## `untitleize(name)`
+
+文字列 `name` の最初の文字を小文字にし、残りの文字はそのままにします。
+
+*   `name`: 変換する文字列。
+
+**戻り値:** 最初の文字が小文字化された文字列。`name` が空の場合は空文字列を返します。
+
+**実行例:**
+
+```python
+from dictknife.naming import untitleize
+
+u1 = untitleize("Hello")
+# u1 is "hello"
+
+u2 = untitleize("WORLD")
+# u2 is "wORLD"
+
+u3 = untitleize("alreadyUntitled")
+# u3 is "alreadyUntitled"
+
+u4 = untitleize("")
+# u4 is ""
+
+u5 = untitleize("1St")
+# u5 is "1St" (最初の文字が非アルファベットの場合、そのまま)
+```
+```

--- a/docs/apidoc/operators.md
+++ b/docs/apidoc/operators.md
@@ -1,0 +1,218 @@
+```markdown
+# `dictknife.operators`
+
+このモジュールは、値のフィルタリングや条件評価に使用できる演算子クラスとヘルパー関数を提供します。
+主に `dictknife.walkers.DictWalker` などで、探索するキーや値を動的に照合する際に利用されます。
+
+## `apply(q, v, *args)`
+
+条件 `q` を値 `v` (およびオプションの追加引数 `*args`) に適用します。
+
+*   `q`: 適用する条件。
+    *   `q` が呼び出し可能 (callable) な場合: `q(v, *args)` を呼び出し、その結果を返します。
+    *   `q` が呼び出し可能でない場合: `q == v` の結果を返します。
+*   `v`: 条件を適用する対象の値。
+*   `*args`: `q` が呼び出し可能な場合に渡される追加の引数。
+
+**戻り値:** 条件の評価結果 (通常は `bool`)。
+
+**実行例:**
+
+```python
+from dictknife.operators import apply, Regexp
+
+# q が呼び出し可能でない場合 (単純な比較)
+print(apply("hello", "hello")) # True
+print(apply("hello", "world")) # False
+
+# q が呼び出し可能な場合 (Regexp オブジェクト)
+rx = Regexp(r"he.lo")
+print(apply(rx, "hello")) # <re.Match object; span=(0, 5), match='hello'> (True相当)
+print(apply(rx, "world")) # None (False相当)
+
+# q が呼び出し可能な場合 (カスタム関数)
+def is_even(n):
+    return n % 2 == 0
+print(apply(is_even, 4)) # True
+print(apply(is_even, 3)) # False
+```
+
+## `Regexp` クラス
+
+正規表現によるマッチングを行うための演算子です。
+
+### `__init__(self, rx)`
+
+*   `rx`: 正規表現パターン。文字列またはコンパイル済みの正規表現オブジェクト (`re.Pattern`) を指定できます。文字列で渡された場合は内部で `re.compile()` されます。
+
+### `__call__(self, v, *args)`
+
+値 `v` (文字列であると期待される) がコンストラクタで指定された正規表現 `rx` にマッチするかどうかを評価します。`re.search()` を使用するため、文字列の一部にマッチすれば成功とみなされます。
+
+*   `v`: マッチング対象の文字列。
+*   `*args`: 無視されます。
+
+**戻り値:** マッチした場合は `re.Match` オブジェクト、マッチしない場合は `None`。
+
+**実行例:**
+
+```python
+from dictknife.operators import Regexp, apply
+import re
+
+# 文字列で正規表現を指定
+op_str = Regexp(r"^[a-zA-Z]+$")
+print(bool(apply(op_str, "HelloWorld"))) # True
+print(bool(apply(op_str, "HelloWorld123"))) # False
+
+# コンパイル済み正規表現オブジェクトを指定
+compiled_rx = re.compile(r"\d{3}-\d{4}")
+op_compiled = Regexp(compiled_rx)
+print(bool(apply(op_compiled, "123-4567"))) # True
+print(bool(apply(op_compiled, "abc-defg"))) # False
+```
+
+## `Any` クラス (および `ANY` インスタンス)
+
+常に `True` を返す演算子です。どのような値に対してもマッチします。
+シングルトンインスタンス `ANY` が提供されています。
+
+### `__call__(self, v, *args)`
+
+*   `v`: 任意の値。
+*   `*args`: 無視されます。
+
+**戻り値:** 常に `True`。
+
+**実行例:**
+
+```python
+from dictknife.operators import ANY, apply # または from dictknife.operators import Any; ANY = Any()
+
+print(apply(ANY, "anything"))    # True
+print(apply(ANY, None))          # True
+print(apply(ANY, 123))           # True
+```
+
+## `Not` クラス
+
+指定された条件演算子の結果を否定する演算子です。
+
+### `__init__(self, value)`
+
+*   `value`: 否定する条件。これはリテラル値、または他の演算子インスタンス (`Regexp`, `Any`, `Or`, `And`) などです。
+
+### `__call__(self, v, *args)`
+
+内部で `apply(self.args, v, *args)` を呼び出し、その結果を論理否定 (`not`) して返します。
+
+*   `v`: 評価対象の値。
+*   `*args`: 内部の `apply` に渡される追加引数。
+
+**戻り値:** 指定された条件の評価結果の否定 (`bool`)。
+
+**実行例:**
+
+```python
+from dictknife.operators import Not, Regexp, apply
+
+# "hello" ではない場合に True
+op_not_hello = Not("hello")
+print(apply(op_not_hello, "world")) # True
+print(apply(op_not_hello, "hello")) # False
+
+# 数字で始まらない場合に True
+rx_digits = Regexp(r"^\d")
+op_not_starts_with_digit = Not(rx_digits)
+print(apply(op_not_starts_with_digit, "abc"))  # True (rx_digits は None を返すので not None は True)
+print(apply(op_not_starts_with_digit, "1abc")) # False (rx_digits は Match オブジェクトを返すので not Match は False)
+```
+
+## `Or` クラス
+
+複数の条件演算子のうち、いずれか一つでも `True` を返せば `True` を返す演算子 (論理OR)。
+
+### `__init__(self, args)`
+
+*   `args`: 条件のリストまたはタプル。各要素はリテラル値や他の演算子インスタンスです。
+
+### `__call__(self, v, *args)`
+
+`args` 内の各条件 `e` について `apply(e, v, *args)` を順に評価し、最初に `True` となった時点で `True` を返します。全ての条件が `False` の場合は `False` を返します。
+
+*   `v`: 評価対象の値。
+*   `*args`: 内部の `apply` に渡される追加引数。
+
+**戻り値:** いずれかの条件が真であれば `True`、そうでなければ `False`。
+
+**実行例:**
+
+```python
+from dictknife.operators import Or, Regexp, apply
+
+# "apple", "banana", "cherry" のいずれかであれば True
+op_fruits = Or(["apple", "banana", "cherry"])
+print(apply(op_fruits, "banana"))  # True
+print(apply(op_fruits, "orange"))  # False
+
+# "error" を含むか、全て大文字であれば True
+rx_error = Regexp("error")
+rx_all_caps = Regexp(r"^[A-Z]+$")
+op_or_condition = Or([rx_error, rx_all_caps])
+print(apply(op_or_condition, "This is an error message")) # True (rx_error にマッチ)
+print(apply(op_or_condition, "WARNING"))                 # True (rx_all_caps にマッチ)
+print(apply(op_or_condition, "Normal message"))          # False
+```
+
+## `And` クラス
+
+複数の条件演算子のすべてが `True` を返す場合にのみ `True` を返す演算子 (論理AND)。
+
+### `__init__(self, args)`
+
+*   `args`: 条件のリストまたはタプル。各要素はリテラル値や他の演算子インスタンスです。
+
+### `__call__(self, v, *args)`
+
+`args` 内の各条件 `e` について `apply(e, v, *args)` を順に評価し、最初に `False` となった時点で `False` を返します。全ての条件が `True` の場合は `True` を返します。
+
+*   `v`: 評価対象の値。
+*   `*args`: 内部の `apply` に渡される追加引数。
+
+**戻り値:** すべての条件が真であれば `True`、そうでなければ `False`。
+
+**実行例:**
+
+```python
+from dictknife.operators import And, Not, Regexp, apply
+
+# "admin" であり、かつ "password" ではない場合に True (例: ユーザー名として適切か)
+op_user_check = And(["admin", Not("password")]) # "admin" はリテラル値との比較
+# この例は意図通りに動かない可能性あり。"admin"という文字列そのものと比較するため。
+# 正しくは以下のように Regexp を使うか、あるいは apply の第一引数が評価対象の値と等しいかを期待する。
+
+# "admin" という文字列に一致し、かつ "password" という文字列には一致しない場合
+op_user_check_strict = And([Regexp("^admin$"), Not(Regexp("^password$"))])
+# apply(op_user_check_strict, "admin") -> True
+# apply(op_user_check_strict, "password") -> False
+# apply(op_user_check_strict, "user") -> False
+
+
+# 3文字以上で、かつ全てアルファベットである場合に True
+rx_min_len_3 = Regexp(r".{3,}")
+rx_alpha_only = Regexp(r"^[a-zA-Z]+$")
+op_alpha_3plus = And([rx_min_len_3, rx_alpha_only])
+
+print(apply(op_alpha_3plus, "abc"))    # True
+print(apply(op_alpha_3plus, "ab"))     # False (長さが足りない)
+print(apply(op_alpha_3plus, "abc1"))   # False (数字が含まれる)
+print(apply(op_alpha_3plus, "longerword")) # True
+
+# テストコードで見られた組み合わせ例
+# Not("x") AND "xx" AND Not("xxx")
+op_complex = And([Not("x"), "xx", Not("xxx")])
+print(apply(op_complex, "x"))   # False
+print(apply(op_complex, "xx"))  # True
+print(apply(op_complex, "xxx")) # False
+```
+```

--- a/docs/apidoc/pp.md
+++ b/docs/apidoc/pp.md
@@ -1,0 +1,144 @@
+```markdown
+# `dictknife.pp`
+
+このモジュールは、Pythonのデータ構造 (主に辞書やリスト) を人間が読みやすい形に整形 (pretty print) して出力するためのユーティリティを提供します。
+
+## `pp(d, out=None)`
+
+データ `d` を整形して `out` (デフォルトは標準出力 `sys.stdout`) に出力します。
+内部では `json.dump()` を利用しており、以下のデフォルト設定で呼び出されます:
+*   `sort_keys=True` (キーでソートされる)
+*   `indent=2` (2スペースでインデント)
+*   `ensure_ascii=False` (非ASCII文字をそのまま出力)
+*   `default=str` (JSONシリアライズ不可能なオブジェクトは `str()` で文字列化)
+
+もし `json.dump()` が `TypeError` (例えば、ソート不可能な型のキーが存在する場合など) を送出した場合、`sort_keys=False` として再度 `json.dump()` を試みます。
+
+*   `d`: 出力するデータ構造。
+*   `out`: 出力先のストリームオブジェクト。デフォルトは `sys.stdout`。
+
+**実行例:**
+
+```python
+from dictknife.pp import pp
+import sys
+from io import StringIO
+
+data = {
+    "name": "テストユーザー",
+    "age": 30,
+    "active": True,
+    "address": {"city": "東京", "zip": None},
+    "tags": ["Python", "dictknife"]
+}
+
+# 標準出力へ出力
+# pp(data)
+# 出力結果 (標準出力に):
+# {
+#   "active": true,
+#   "address": {
+#     "city": "東京",
+#     "zip": null
+#   },
+#   "age": 30,
+#   "name": "テストユーザー",
+#   "tags": [
+#     "Python",
+#     "dictknife"
+#   ]
+# }
+
+# StringIO を使って文字列として取得
+buffer = StringIO()
+pp(data, out=buffer)
+output_str = buffer.getvalue()
+print(output_str)
+# 出力結果 (printによって):
+# {
+#   "active": true,
+#   "address": {
+#     "city": "東京",
+#     "zip": null
+#   },
+#   "age": 30,
+#   "name": "テストユーザー",
+#   "tags": [
+#     "Python",
+#     "dictknife"
+#   ]
+# }
+
+# ソート不可能なキーを含む場合のフォールバック (例として)
+data_unsortable = {
+    1: "one",
+    None: "null_key", # 通常、キーにNoneは推奨されないが、TypeErrorの例として
+    "b": "bee"
+}
+# pp(data_unsortable) # Python 3では sort_keys=True でも TypeError にならないことがある
+                      # json.dump のデフォルトの挙動に依存
+                      # この例では TypeError が発生しにくいが、もし発生した場合は sort_keys=False で試行される
+```
+
+## `indent(n, prefix=None, newline=True)`
+
+指定されたインデント `n` (スペース数) を付けて標準出力の内容を整形するためのコンテキストマネージャです。
+`with` ブロック内の標準出力 (`sys.stdout`) への書き込みを一時的にキャプチャし、ブロックを抜ける際にキャプチャした内容全体にインデントとオプションのプレフィックスを適用して、元の標準出力へ書き出します。
+
+*   `n`: インデントするスペースの数。
+*   `prefix=None`: インデントされたブロック全体の前に挿入する文字列。
+*   `newline=True`: `prefix` が指定された場合、`prefix` の後に改行を挿入するかどうか。
+
+**コンテキストマネージャが `yield` する値:**
+ブロック内で標準出力の代わりに書き込みに使用できる `io.StringIO` バッファ。ただし、通常はブロック内で普通に `print()` などを使用すれば、それがキャプチャされます。
+
+**実行例:**
+
+```python
+from dictknife.pp import indent, pp
+
+data1 = {"id": 1, "value": "first"}
+data2 = {"id": 2, "value": "second"}
+
+print("Raw output:")
+pp(data1)
+
+print("\nIndented output:")
+with indent(4, prefix="-- Start Block --"):
+    print("This is the first line inside the block.")
+    pp(data1) # ppも標準出力を使うのでインデントされる
+    print("And another line.")
+    with indent(4, prefix="---- Nested Block ----"): # ネストも可能
+        pp(data2)
+    print("Back to first level of indent.")
+print("-- End Block -- (This line is not indented by the context manager)")
+
+# 出力結果:
+# Raw output:
+# {
+#   "id": 1,
+#   "value": "first"
+# }
+#
+# Indented output:
+# -- Start Block --
+#     This is the first line inside the block.
+#     {
+#       "id": 1,
+#       "value": "first"
+#     }
+#     And another line.
+#     ---- Nested Block ----
+#         {
+#           "id": 2,
+#           "value": "second"
+#         }
+#     Back to first level of indent.
+# -- End Block -- (This line is not indented by the context manager)
+
+# `yield` されるバッファを直接使う例 (あまり一般的ではない)
+# with indent(2) as buf:
+#     buf.write("Hello from buffer\n")
+#     print("Hello from print", file=buf) # このようにバッファを指定する必要がある
+```
+```

--- a/docs/apidoc/shape.md
+++ b/docs/apidoc/shape.md
@@ -1,0 +1,127 @@
+```markdown
+# `dictknife.shape`
+
+このモジュールは、与えられたPythonのデータ構造 (辞書やリスト) を解析し、その「形状」やスキーマの概要を抽出する機能を提供します。具体的には、データ内の各パス、そのパスで見つかる値の型、および代表的なサンプル値をリストアップします。
+コマンドラインツール `dictknife shape` のコアロジックでもあります。
+
+## `shape(d, traverse=Traverser().traverse, aggregate=_build_pathlist_from_state, *, squash=False, skiplist=False, separator="/", transform=as_jsonpointer)`
+
+入力データ `d` の形状を解析し、結果を `Row` オブジェクトのリストとして返します。
+
+*   `d`: 解析対象の辞書またはリスト。
+*   `traverse` (callable, default: `Traverser().traverse`): データ構造を走査し、パスと値の情報を収集する関数。通常はデフォルトのままで使用します。
+*   `aggregate` (callable, default: `_build_pathlist_from_state`): `traverse` によって収集された情報を集約し、最終的な `Row` のリストを生成する関数。通常はデフォルトのままで使用します。
+*   `squash` (bool, default: `False`): `True` の場合、入力データがリストで、かつその要素が辞書である場合に、パスの先頭に来るリスト要素を示すマーカー (`[]/`) を除去します。例えば、`[]/person/name` が `person/name` になります。
+*   `skiplist` (bool, default: `False`): `True` の場合、パスの末尾がリスト要素マーカー (`[]`) で終わるようなエントリ (例: `person/skills/[]`) を結果から除外します。これはリスト自体ではなく、リストの *要素* の型や例を示します。
+*   `separator` (str, default: `/`): 出力されるパス文字列内で、階層を区切るために使用される文字。
+*   `transform` (callable, default: `dictknife.langhelpers.as_jsonpointer`): パスの各要素 (キーやリストマーカー) を文字列に変換する際に使用される関数。デフォルトではJSON Pointerの仕様に従い `/` や `~` をエスケープします。
+
+**戻り値:** `Row` namedtuple のリスト。各 `Row` オブジェクトは以下のフィールドを持ちます。
+    *   `path` (str): データ構造内の要素へのパス。オプショナルな要素の場合、先頭に `?` が付きます。
+    *   `type` (list): そのパスで見つかった値の型 (`type` オブジェクト) のリスト。複数の型が見つかった場合は、それら全てが含まれます (ソート済み)。
+    *   `example` (any): そのパスで見つかった値の代表的な例 (最初に見つかった値)。
+
+### `Row` namedtuple
+
+`Row = namedtuple("Row", "path, type, example")` として定義されています。
+
+### 内部クラスと関数
+
+*   `Traverser`: データ構造を再帰的に走査するクラス。
+    *   `_State`: `Traverser` が収集した中間情報を保持する内部クラス。
+*   `_build_pathlist_from_state`: `_State` オブジェクトから最終的な `Row` リストを構築する関数。
+
+これらの内部コンポーネントは通常、`shape` 関数を通じて間接的に利用されます。
+
+**実行例:**
+
+```python
+from dictknife.shape import shape, Row # Row は戻り値の型確認用にインポート
+from dictknife.langhelpers import as_jsonpointer # デフォルトの transform 関数
+
+data1 = {
+    "name": "Alice",
+    "age": 30,
+    "active": True,
+    "address": {"city": "Tokyo", "zip_code": "100-0000"},
+    "tags": ["python", "developer", "data"]
+}
+
+shape_info1 = shape(data1)
+for row in shape_info1:
+    print(f"Path: {row.path}, Types: {[t.__name__ for t in row.type]}, Example: {row.example!r}")
+# 出力例 (順不同の可能性あり):
+# Path: active, Types: ['bool'], Example: True
+# Path: address, Types: ['dict'], Example: {'city': 'Tokyo', 'zip_code': '100-0000'}
+# Path: address/city, Types: ['str'], Example: 'Tokyo'
+# Path: address/zip_code, Types: ['str'], Example: '100-0000'
+# Path: age, Types: ['int'], Example: 30
+# Path: name, Types: ['str'], Example: 'Alice'
+# Path: tags, Types: ['list'], Example: ['python', 'developer', 'data']
+# Path: tags/[], Types: ['str'], Example: 'python'
+
+print("-" * 20)
+
+data2 = [
+    {"id": 1, "type": "A", "value": 100, "optional_field": "present"},
+    {"id": 2, "type": "B", "value": 200},
+    {"id": 3, "type": "A", "value": 150.5, "tags": ["tag1"]},
+]
+
+# squash と skiplist の効果を見る
+shape_info2_default = shape(data2)
+print("--- Default ---")
+for row in shape_info2_default:
+    print(f"Path: {row.path}, Types: {[t.__name__ for t in row.type]}, Example: {row.example!r}")
+# 出力例 (抜粋):
+# Path: [], Types: ['dict'], Example: {'id': 1, 'type': 'A', 'value': 100, 'optional_field': 'present'}
+# Path: []/id, Types: ['int'], Example: 1
+# Path: []/type, Types: ['str'], Example: 'A'
+# Path: []/value, Types: ['float', 'int'], Example: 100
+# Path: ?[]/optional_field, Types: ['str'], Example: 'present'
+# Path: ?[]/tags, Types: ['list'], Example: ['tag1']
+# Path: ?[]/tags/[], Types: ['str'], Example: 'tag1'
+
+
+shape_info2_squashed = shape(data2, squash=True)
+print("\n--- Squashed ---")
+for row in shape_info2_squashed:
+    print(f"Path: {row.path}, Types: {[t.__name__ for t in row.type]}, Example: {row.example!r}")
+# 出力例 (抜粋, []/ が除去される):
+# Path: id, Types: ['int'], Example: 1
+# Path: type, Types: ['str'], Example: 'A'
+# Path: value, Types: ['float', 'int'], Example: 100
+# Path: ?optional_field, Types: ['str'], Example: 'present'
+# Path: ?tags, Types: ['list'], Example: ['tag1']
+# Path: ?tags/[], Types: ['str'], Example: 'tag1' (tags自体がオプショナルなので、その子もオプショナル扱いになることがある)
+
+
+shape_info2_squash_skip = shape(data2, squash=True, skiplist=True)
+print("\n--- Squashed & Skiplist ---")
+for row in shape_info2_squash_skip:
+    print(f"Path: {row.path}, Types: {[t.__name__ for t in row.type]}, Example: {row.example!r}")
+# 出力例 (抜粋, tags/[] がなくなる):
+# Path: id, Types: ['int'], Example: 1
+# Path: type, Types: ['str'], Example: 'A'
+# Path: value, Types: ['float', 'int'], Example: 100
+# Path: ?optional_field, Types: ['str'], Example: 'present'
+# Path: ?tags, Types: ['list'], Example: ['tag1']
+
+# transform を変える例 (JSON Pointerエスケープをしない)
+def no_transform(x): return str(x)
+data3 = {"foo/bar": 1}
+shape_info3_no_transform = shape(data3, transform=no_transform)
+print("\n--- No Transform ---")
+for row in shape_info3_no_transform:
+    print(f"Path: {row.path}")
+# 出力: Path: foo/bar
+
+shape_info3_default_transform = shape(data3) # default is as_jsonpointer
+print("\n--- Default Transform (as_jsonpointer) ---")
+for row in shape_info3_default_transform:
+    print(f"Path: {row.path}")
+# 出力: Path: foo~1bar
+```
+
+このモジュールは、未知のデータ構造の概要を把握したり、複数のデータインスタンスから共通のスキーマを推測したり、あるいは設定ファイルのテンプレートを生成する際などに役立ちます。
+```

--- a/docs/apidoc/transform.md
+++ b/docs/apidoc/transform.md
@@ -1,0 +1,286 @@
+```markdown
+# `dictknife.transform`
+
+このモジュールは、辞書やリストのデータ構造を様々な形式に変換したり、特定の条件に基づいて要素を抽出・変更したりするための関数群を提供します。コマンドラインツール `dictknife transform` のコアロジックの一部としても利用されます。
+
+## `flatten(d, *, sep="/")`
+
+ネストされた辞書やリスト `d` を、キーがフラット化された一層の辞書に変換します。
+ネストしたキーは `sep` (デフォルトは `/`) で連結されます。リストのインデックスもキーの一部として扱われます。
+
+*   `d`: フラット化する対象の辞書またはリスト。
+*   `sep` (str, default: `/`): ネストしたキーを連結する際のセパレータ。
+
+**戻り値:** フラット化された辞書。
+
+**実行例:**
+
+```python
+from dictknife.transform import flatten
+
+data = {
+    "user": {
+        "name": "Alice",
+        "age": 30,
+        "emails": ["alice@example.com", "personal@example.net"]
+    },
+    "status": "active"
+}
+
+flat_data = flatten(data)
+print(flat_data)
+# 出力 (キーの順序は不定):
+# {
+#   'user/name': 'Alice',
+#   'user/age': 30,
+#   'user/emails/0': 'alice@example.com',
+#   'user/emails/1': 'personal@example.net',
+#   'status': 'active'
+# }
+
+# セパレータを変更
+flat_data_dot_sep = flatten(data, sep=".")
+print(flat_data_dot_sep)
+# 出力 (キーの順序は不定):
+# {
+#   'user.name': 'Alice',
+#   'user.age': 30,
+#   'user.emails.0': 'alice@example.com',
+#   'user.emails.1': 'personal@example.net',
+#   'status': 'active'
+# }
+```
+*注意: 値が単純な非コンテナ型の場合、キーは `None` となり、値はそのまま (ただし文字列の場合はJSON Pointerエスケープされる) になります。例: `flatten("text")` -> `{None: "text"}`*
+
+## `unflatten(d, *, sep="/", accessor=accessing.Accessor())`
+
+`flatten` 関数によってフラット化された辞書 `d` を、元のネストされた構造 (辞書やリスト) に戻します。
+キーは `sep` (デフォルトは `/`) を基準に分割され、階層構造が復元されます。数値のみのキーはリストのインデックスとして解釈しようとします。
+
+*   `d`: アンフラット化する対象のフラットな辞書。
+*   `sep` (str, default: `/`): キーを分割するためのセパレータ。
+*   `accessor` (object, default: `dictknife.accessing.Accessor()` instance): 内部でネスト構造を構築する際に使用するアクセサ。
+
+**戻り値:** ネストされた辞書またはリスト。
+
+**実行例:**
+
+```python
+from dictknife.transform import unflatten
+
+flat_data = {
+    'user/name': 'Alice',
+    'user/age': 30,
+    'user/emails/0': 'alice@example.com',
+    'user/emails/1': 'personal@example.net',
+    'status': 'active'
+}
+
+nested_data = unflatten(flat_data)
+print(nested_data)
+# 出力:
+# {
+#   'user': {
+#     'name': 'Alice',
+#     'age': 30,
+#     'emails': ['alice@example.com', 'personal@example.net']
+#   },
+#   'status': 'active'
+# }
+
+flat_data_list_only = {
+    '0/name': 'item0',
+    '1/name': 'item1'
+}
+nested_list = unflatten(flat_data_list_only)
+print(nested_list)
+# 出力: [{'name': 'item0'}, {'name': 'item1'}]
+```
+
+## `rows(d, *, kname="name", vname="value")`
+
+辞書 `d` を、各キーと値のペアを行オブジェクト (辞書) とするリストに変換します。
+
+*   `d`: 変換対象の辞書。
+*   `kname` (str, default: `"name"`): 結果の行オブジェクト内で、元のキーを格納する際のキー名。
+*   `vname` (str, default: `"value"`): 結果の行オブジェクト内で、元の値を格納する際のキー名。
+
+**戻り値:** 行オブジェクト (辞書) のリスト。
+
+**実行例:**
+
+```python
+from dictknife.transform import rows
+
+data = {"name": "Alice", "age": 30, "city": "Tokyo"}
+row_list = rows(data)
+print(row_list)
+# 出力:
+# [
+#   {'name': 'name', 'value': 'Alice'},
+#   {'name': 'age', 'value': 30},
+#   {'name': 'city', 'value': 'Tokyo'}
+# ]
+
+row_list_custom_names = rows(data, kname="key", vname="val")
+print(row_list_custom_names)
+# 出力:
+# [
+#   {'key': 'name', 'val': 'Alice'},
+#   {'key': 'age', 'val': 30},
+#   {'key': 'city', 'val': 'Tokyo'}
+# ]
+```
+
+## `update_keys(d, *, key, coerce=str)`
+
+辞書 `d` (およびネストされた辞書) 内のすべてのキーを、指定された `key` 関数によって変換します。この操作は **破壊的** (元の辞書を変更) です。
+
+*   `d`: キーを変換する対象の辞書。
+*   `key` (callable): 各キー (`str` 型に `coerce` された後) を引数に取り、変換後のキー文字列を返す関数。
+*   `coerce` (callable, default: `str`): キーを `key` 関数に渡す前に適用する型変換関数。
+
+**戻り値:** キーが変換された元の辞書オブジェクト `d`。
+
+**実行例:**
+
+```python
+from dictknife.transform import update_keys
+from dictknife.naming import camelcase # dictknife.naming からインポート
+
+data = {"first_name": "Alice", "last_name": "Smith", "contact_info": {"email_address": "alice@example.com"}}
+
+# キーをすべて大文字に変換
+update_keys(data.copy(), key=lambda k: k.upper())
+# data は変更されるので、コピーに対して操作する例
+# print(data) # -> {'FIRST_NAME': 'Alice', 'LAST_NAME': 'Smith', 'CONTACT_INFO': {'EMAIL_ADDRESS': 'alice@example.com'}}
+
+# キーをキャメルケースに変換 (dictknife.namingを利用)
+data_for_camel = {"first_name": "Bob", "user_age": 25, "address_details": {"street_name": "Main St"}}
+update_keys(data_for_camel, key=camelcase)
+print(data_for_camel)
+# 出力: {'firstName': 'Bob', 'userAge': 25, 'addressDetails': {'streetName': 'Main St'}}
+```
+
+### `update_keys` の派生関数
+
+`update_keys` を `functools.partial` で特殊化した、特定の命名規則にキーを一括変換する便利な関数が提供されています。これらはすべて **破壊的** です。
+
+*   `str_dict(d)`: キーを `str()` で変換 (主に型の一貫性のため)。
+*   `normalize_dict(d)`: キーを `dictknife.naming.normalize` で正規化。
+*   `snakecase_dict(d)`: キーを `dictknife.naming.snakecase` でスネークケースに変換。
+*   `camelcase_dict(d)`: キーを `dictknife.naming.camelcase` でキャメルケースに変換。
+*   `kebabcase_dict(d)`: キーを `dictknife.naming.kebabcase` でケバブケースに変換。
+*   `pascalcase_dict(d)`: キーを `dictknife.naming.pascalcase` でパスカルケースに変換。
+
+**実行例 (派生関数):**
+
+```python
+from dictknife.transform import snakecase_dict, camelcase_dict
+
+data_pascal = {"UserName": "Carol", "EmailAddress": "carol@example.com", "IsActive": True}
+snakecase_dict(data_pascal.copy()) # コピーに対して操作
+# data_pascal は {'user_name': 'Carol', 'email_address': 'carol@example.com', 'is_active': True} になる
+
+data_snake = {"user_name": "David", "email_address": "david@example.com", "is_active": False}
+camelcase_dict(data_snake) # 直接変更
+print(data_snake)
+# 出力: {'userName': 'David', 'emailAddress': 'david@example.com', 'isActive': False}
+```
+
+## `only_num(d)`
+
+辞書 `d` のうち、値が数値 ( `int` または `float`、ただし `bool` は除く) であるか、または数値として解釈できる文字列 (`isdigit()` が `True`) である要素のみを含む新しい辞書を返します。
+
+*   `d`: フィルタリング対象の辞書。
+
+**戻り値:** フィルタリングされた新しい辞書。
+
+**実行例:**
+
+```python
+from dictknife.transform import only_num
+
+data = {"name": "Test", "count": 10, "ratio": 0.75, "id_str": "12345", "active": True, "code": "A1"}
+numeric_data = only_num(data)
+print(numeric_data)
+# 出力 (キーの順序は不定):
+# {'count': 10, 'ratio': 0.75, 'id_str': '12345'}
+```
+
+## `only_str(d)`
+
+辞書 `d` のうち、値が文字列 (`str`) である要素のみを含む新しい辞書を返します。
+
+*   `d`: フィルタリング対象の辞書。
+
+**戻り値:** フィルタリングされた新しい辞書。
+
+**実行例:**
+
+```python
+from dictknife.transform import only_str
+
+data = {"name": "Test", "count": 10, "id_str": "12345", "active": True, "code": "A1"}
+string_data = only_str(data)
+print(string_data)
+# 出力 (キーの順序は不定):
+# {'name': 'Test', 'id_str': '12345', 'code': 'A1'}
+```
+
+## `shrink(d, *, max_length_of_string=100, cont_suffix="...", max_length_of_list=3, with_tail=False, mutable=False)`
+
+データ構造 `d` (辞書やリスト) 内の長い文字列や長いリストを指定された長さに縮小します。ログ出力やデータの概要表示などに便利です。
+
+*   `d`: 縮小対象のデータ構造。
+*   `max_length_of_string` (int, default: 100): 文字列の最大長。これを超えた文字列は切り詰められ、`cont_suffix` が付加されます。
+*   `cont_suffix` (str, default: `...`): 切り詰められた文字列の末尾に付加される接尾辞。
+*   `max_length_of_list` (int, default: 3): リストの最大長。これを超えたリストは先頭からこの長さまで切り詰められます。
+*   `with_tail` (bool, default: `False`): `True` の場合、リストが切り詰められる際に、先頭要素だけでなく末尾の要素も `max_length_of_list` 分だけ保持しようとします (現在は実装上、先頭に追加される形になっています)。
+*   `mutable` (bool, default: `False`): `True` の場合、元のデータ構造を直接変更 (破壊的変更) します。`False` の場合は新しいデータ構造を返します。
+
+**戻り値:** 縮小されたデータ構造 ( `mutable=False` の場合) または元のデータ構造への参照 ( `mutable=True` の場合)。
+
+**実行例:**
+
+```python
+from dictknife.transform import shrink
+
+data = {
+    "description": "This is a very long string that definitely exceeds the default maximum length of one hundred characters, so it should be truncated.",
+    "items": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    "config": {
+        "key": "another long string for testing purposes, let's see if this also gets cut off as expected by the shrink function."
+    },
+    "empty_list": [],
+    "short_string": "Hello"
+}
+
+shrunk_data_immutable = shrink(data)
+print("--- Immutable Shrink ---")
+print(shrunk_data_immutable)
+# 出力例 (description と config.key が切り詰められ、items が短縮される):
+# {
+#   'description': 'This is a very long string that definitely exceeds the default maximum length of one hundred charact...',
+#   'items': [1, 2, 3],
+#   'config': {
+#     'key': "another long string for testing purposes, let's see if this also gets cut off as expected by the sh..."
+#   },
+#   'empty_list': [],
+#   'short_string': 'Hello'
+# }
+
+shrunk_data_mutable = data.copy() # 元データを壊さないようにコピー
+shrink(shrunk_data_mutable, max_length_of_string=30, max_length_of_list=2, mutable=True)
+print("\n--- Mutable Shrink (max_string=30, max_list=2) ---")
+print(shrunk_data_mutable)
+# 出力例:
+# {
+#   'description': 'This is a very long string th...',
+#   'items': [1, 2],
+#   'config': {'key': "another long string for testi..."},
+#   'empty_list': [],
+#   'short_string': 'Hello'
+# }
+```
+```

--- a/docs/apidoc/walkers.md
+++ b/docs/apidoc/walkers.md
@@ -1,0 +1,150 @@
+```markdown
+# `dictknife.walkers`
+
+このモジュールは、ネストされた辞書やリストなどのデータ構造を柔軟に探索・走査するためのクラスを提供します。中心となるのは `DictWalker` クラスで、探索条件やコンテキスト、結果の処理方法をカスタマイズできます。
+
+## `DictWalker` クラス
+
+ネストされた辞書やリストを再帰的に探索し、指定された条件 (`qs`) にマッチする要素を見つけ出すためのイテレータを提供します。
+
+**エイリアス:** `LooseDictWalkingIterator` (後方互換性のためのエイリアスです。新しいコードでは `DictWalker` の使用を推奨します。)
+
+### `__init__(self, qs, handler=None, context_factory=None)`
+
+*   `qs`: クエリのシーケンス (リストやタプル)。探索するパスの各階層に対する条件を指定します。
+    *   各要素は、リテラル値 (キー名やインデックスと直接比較) や、`dictknife.operators` モジュールで定義された演算子 (`Regexp`, `Any`, `Not`, `Or`, `And` など) のインスタンスです。
+    *   例えば、`["users", ANY, "name"]` は、トップレベルの `users` キー -> 任意のキー/インデックス -> `name` キー、というパスを探索します。
+*   `handler=None`: マッチした要素が見つかった場合に、その要素をどのように処理するかを定義するハンドラオブジェクト。
+    *   デフォルトは `ContainerHandler` インスタンスです。
+    *   `DataHandler` やカスタムハンドラを指定できます。
+*   `context_factory=None`: 探索中のコンテキスト情報を管理するオブジェクトを生成するファクトリ関数またはクラス。
+    *   デフォルトは `PathContext` です。
+    *   `SimpleContext`, `RecPathContext` やカスタムコンテキストファクトリを指定できます。
+
+### `walk(self, d, qs=None, depth=-1, ctx=None)`
+
+データ構造 `d` を探索し、条件にマッチした要素をyieldするジェネレータメソッドです。
+
+*   `d`: 探索対象の辞書またはリスト。
+*   `qs=None`: `__init__` で指定したものと異なるクエリシーケンスを使用する場合に指定。デフォルトは `__init__` で指定された `qs` を使用。
+*   `depth=-1`: 探索する最大の深さ。
+    *   `-1` (デフォルト): 深さ制限なし。
+    *   `0`: 何も探索しません。
+    *   `1`: トップレベルのみ探索。
+*   `ctx=None`: `__init__` で指定したものと異なるコンテキストオブジェクトを初期状態で使用する場合に指定。
+
+**戻り値 (yield):**
+ハンドラ (`self.handler`) とコンテキスト (`ctx`) の組み合わせによって、yieldされる値の形式が決まります。
+デフォルトの `PathContext` と `ContainerHandler` の組み合わせでは、`on_found` メソッドは `ctx(walker, self.handler.identity, d)` を呼び出し、`PathContext` は `fn(self.path, value)` を実行するので、`(path_list, container_dict)` のようなタプルがyieldされることが期待されます。ここで `path_list` はマッチした要素までのパス、`container_dict` はマッチしたキーを含むコンテナです。
+
+**エイリアス:** `iterate` (後方互換性のためのエイリアスです。)
+
+**実行例:**
+
+```python
+from dictknife.walkers import DictWalker
+from dictknife.operators import ANY, Regexp
+
+data = {
+    "users": [
+        {"id": 1, "name": "Alice", "settings": {"theme": "dark", "active": True}},
+        {"id": 2, "name": "Bob", "email": "bob@example.com"},
+        {"id": 3, "name": "Charlie", "settings": {"theme": "light", "active": False}},
+    ],
+    "config": {"version": "1.0", "debug_mode": False}
+}
+
+# 例1: 全てのユーザーの名前を取得
+# qs: "users" キー -> 任意インデックス -> "name" キー
+walker_names = DictWalker(["users", ANY, "name"])
+for path, name_value_container in walker_names.walk(data):
+    # デフォルトハンドラ(ContainerHandler)はキーを含むコンテナを返す
+    # path は ['users', (インデックス), 'name']
+    # name_value_container は {'name': 'xxx'} のような辞書
+    print(f"Path: {path}, Value: {name_value_container[path[-1]]}")
+# 出力例:
+# Path: ['users', 0, 'name'], Value: Alice
+# Path: ['users', 1, 'name'], Value: Bob
+# Path: ['users', 2, 'name'], Value: Charlie
+
+# 例2: 'settings' の中の 'theme' の値を取得 (DataHandlerを使用)
+from dictknife.walkers import DataHandler
+walker_themes = DictWalker(
+    ["users", ANY, "settings", "theme"],
+    handler=DataHandler()
+)
+for path, theme_value in walker_themes.walk(data):
+    # DataHandler は実際の値を返す
+    # path は ['users', (インデックス), 'settings', 'theme']
+    print(f"Path: {path}, Theme: {theme_value}")
+# 出力例:
+# Path: ['users', 0, 'settings', 'theme'], Theme: dark
+# Path: ['users', 2, 'settings', 'theme'], Theme: light
+
+# 例3: 正規表現でキーに 'id' を含むものを探す (深さ制限あり)
+walker_ids = DictWalker([Regexp(r"id")], handler=DataHandler())
+for path, id_value in walker_ids.walk(data, depth=2): # usersリスト内のidは深さ3なのでマッチしない
+    print(f"Path: {path}, ID Value: {id_value}")
+# "users" キー自体は depth=1、その中の辞書は depth=2、辞書内の "id" は depth=3
+# この例では何も出力されないか、あるいは意図しないトップレベルのキーにマッチする可能性がある。
+# クエリを ["users", ANY, Regexp(r"id")] のように具体的にするか、depth調整が必要。
+
+# より正確なID探索の例
+walker_user_ids = DictWalker(["users", ANY, "id"], handler=DataHandler())
+for path, user_id in walker_user_ids.walk(data):
+    print(f"Path: {path}, User ID: {user_id}")
+# 出力例:
+# Path: ['users', 0, 'id'], User ID: 1
+# Path: ['users', 1, 'id'], User ID: 2
+# Path: ['users', 2, 'id'], User ID: 3
+```
+
+### `on_found(self, ctx, d, k)`
+
+内部メソッド。条件に完全にマッチした際 (`qs` の条件を全て満たしたパスが見つかった時) に呼び出され、`self.handler` を介して結果をyieldします。
+
+### `create_context(self, ctx=None)`
+
+内部メソッド。探索のためのコンテキストオブジェクトを生成または返します。
+
+## コンテキストクラス
+
+探索中に現在のパスや状態を管理します。`DictWalker` の `context_factory` に指定します。
+
+### `SimpleContext`
+
+最も基本的なコンテキスト。パス情報は保持しません。
+`__call__(self, walker, fn, value)` は `fn(value)` を呼び出します。
+
+### `PathContext` (デフォルト)
+
+探索中の現在のパス (キー/インデックスのリスト) を `self.path` に保持します。
+`__call__(self, walker, fn, value)` は `fn(self.path, value)` を呼び出します。
+
+### `RecPathContext`
+
+`PathContext` を継承。
+`__call__(self, walker, fn, value)` は `fn(walker, self.path, value)` を呼び出し、ウォーカー自身も渡します。
+
+## ハンドラクラス
+
+`DictWalker` が条件にマッチする要素を見つけたときに、その要素をどのように処理 (yield) するかを定義します。`DictWalker` の `handler` に指定します。
+
+### `ContainerHandler` (デフォルト)
+
+マッチしたキー `k` を含むコンテナ `d` を、コンテキストを通じて処理します。
+デフォルトの `PathContext` と組み合わせると、`(path_to_k, d)` のような形式で結果が渡されることが多いです (実際には `ctx(walker, self.identity, d)` が呼び出され、`PathContext` は `self.identity(path, d)` を呼び、結果として `(path, d)` が返る)。 `d[k]` で実際の値にアクセスできます。
+
+### `DataHandler`
+
+マッチした実際のデータ `d[k]` を、コンテキストを通じて処理します。
+デフォルトの `PathContext` と組み合わせると、`(path_to_k, d[k])` のような形式で結果が渡されることが多いです (実際には `ctx(walker, self.identity, d[k])` が呼び出され、`PathContext` は `self.identity(path, d[k])` を呼び、結果として `(path, d[k])` が返る)。
+
+---
+
+**利用上の注意点:**
+`DictWalker` の `walk` (または `iterate`) メソッドがyieldする値の具体的な形式は、`context_factory` と `handler` の組み合わせによって変わります。
+デフォルトの `PathContext` と `ContainerHandler` の場合、`for path, container in walker.walk(data): ...` のように受け取り、`container[path[-1]]` で値にアクセスできます。
+`PathContext` と `DataHandler` の場合は `for path, value in walker.walk(data): ...` のように直接値を受け取れます。
+ドキュメントの実行例も参照し、使用するコンテキストとハンドラに応じて適切に結果を処理してください。
+```


### PR DESCRIPTION
以下のdictknifeモジュールについて、APIドキュメント（Markdown形式、日本語）を新規に作成しました。

- dictknife.langhelpers
- dictknife.mkdict
- dictknife.naming
- dictknife.operators
- dictknife.pp
- dictknife.shape
- dictknife.transform
- dictknife.walkers
- dictknife.loading.modification パッケージ

既存ドキュメントのスタイルを踏襲し、各モジュール/パッケージの機能、主要な関数・クラス、引数、戻り値、および実行例を記載しました。 また、既存ドキュメントとの整合性を確認し、軽微な修正を行いました。