### PR TITLE
feat: Add English docstrings to public APIs

### DIFF
--- a/src/dictknife/accessing.py
+++ b/src/dictknife/accessing.py
@@ -3,6 +3,12 @@ from .langhelpers import make_dict
 
 
 class Accessor:
+    """Provides methods for accessing and modifying nested dictionary-like objects.
+
+    Attributes:
+        make_dict: A function to create new dictionary-like objects.
+        zero_value: The value to use when an index is out of bounds in a list.
+    """
     def __init__(self, make_dict=make_dict, zero_value=None) -> None:
         self.make_dict = make_dict
         self.zero_value = zero_value
@@ -159,6 +165,21 @@ class MutableModifier:
 
 
 def dictmap(fn, x, *, mutable: bool = False, with_key: bool = False):
+    """Recursively applies a function to the values of a dictionary-like object.
+
+    Args:
+        fn: The function to apply to each value.
+        x: The dictionary-like object to map.
+        mutable: If True, modifies the original object in place.
+                 Otherwise, returns a new object.
+        with_key: If True, the function `fn` will be called with the key as the first argument
+                  and the value as the second argument for dictionary elements.
+                  For list elements, it's called with the value only.
+                  If False (default), `fn` is always called with the value only.
+
+    Returns:
+        The mapped dictionary-like object.
+    """
     modifier = get_modifier(mutable=mutable)
     if with_key:
         modify_dict = modifier.modify_dict_with_keys

--- a/src/dictknife/deepequal.py
+++ b/src/dictknife/deepequal.py
@@ -2,6 +2,18 @@ from .langhelpers import reify
 
 
 def deepequal(d0, d1, normalize: bool = False):
+    """Recursively compares two dictionary-like objects for equality.
+
+    Args:
+        d0: The first dictionary-like object.
+        d1: The second dictionary-like object.
+        normalize (bool, optional): If True, sorts lists and dictionary keys
+            before comparison. This allows for equality checks even if the
+            order of elements is different. Defaults to False.
+
+    Returns:
+        True if the objects are deeply equal, False otherwise.
+    """
     if normalize:
         d0 = sort_flexibly(d0)
         d1 = sort_flexibly(d1)

--- a/src/dictknife/deepmerge.py
+++ b/src/dictknife/deepmerge.py
@@ -95,7 +95,30 @@ METHODS = ["merge", "append", "addtoset", "replace"]
 
 
 def deepmerge(*ds, override: bool = False, method: str = "addtoset"):
-    """deepmerge: methods in {METHODS!r}""".format(METHODS=METHODS)
+    """Recursively merges multiple dictionary-like objects.
+
+    Args:
+        *ds: A variable number of dictionary-like objects to merge.
+        override (bool, optional): Deprecated. If True, uses the 'replace' method.
+            Defaults to False.
+        method (str, optional): The merge strategy to use.
+            Available methods are:
+            - 'addtoset': (Default) Extends lists and sets, ensuring uniqueness in lists.
+                          For dicts, merges keys, recursively merging values.
+            - 'append': Extends lists and sets without ensuring uniqueness.
+                        For dicts, merges keys, recursively merging values.
+            - 'merge': For lists and tuples, merges elements pairwise.
+                       For dicts, merges keys, recursively merging values using 'append' strategy for lists.
+            - 'replace': Replaces the value in the left dictionary with the value from the right.
+                         For lists and tuples, the entire list/tuple is replaced.
+            Defaults to "addtoset".
+
+    Returns:
+        A new dictionary-like object containing the merged data.
+
+    Raises:
+        ValueError: If an invalid merge method is provided.
+    """
     if len(ds) == 0:
         return make_dict()
 

--- a/src/dictknife/diff/diff.py
+++ b/src/dictknife/diff/diff.py
@@ -15,7 +15,30 @@ def diff(
     normalize: bool = False,
     sort_keys: bool = False,
 ):
-    """fancy diff"""
+    """Compares two dictionary-like objects and returns a unified diff.
+
+    Args:
+        d0: The first dictionary-like object.
+        d1: The second dictionary-like object.
+        tostring (callable, optional): A function to convert the objects to strings
+            for comparison. Defaults to a JSON string representation with indentation.
+        fromfile (str, optional): Label for the first object in the diff output.
+            Defaults to "left".
+        tofile (str, optional): Label for the second object in the diff output.
+            Defaults to "right".
+        n (int, optional): Number of context lines to show in the diff. Defaults to 3.
+        terminator (str, optional): The line terminator used when splitting the
+            string representation of objects. Defaults to "\\n".
+        normalize (bool, optional): If True, sorts lists and dictionary keys
+            (flexibly, attempting to handle unorderable types) before comparison.
+            Defaults to False.
+        sort_keys (bool, optional): If True, sorts dictionary keys when converting
+            objects to strings. This is passed to the `tostring` function.
+            Defaults to False.
+
+    Returns:
+        An iterator yielding lines of the unified diff.
+    """
     if normalize:
         d0 = sort_flexibly(d0)
         d1 = sort_flexibly(d1)

--- a/src/dictknife/operators.py
+++ b/src/dictknife/operators.py
@@ -2,6 +2,19 @@ import re
 
 
 def apply(q, v, *args):
+    """Applies a query or callable to a value.
+
+    If `q` is callable, it's called with `v` and any additional `args`.
+    Otherwise, it performs an equality check between `q` and `v`.
+
+    Args:
+        q: The query or callable.
+        v: The value to apply the query to.
+        *args: Additional arguments to pass to the callable if `q` is callable.
+
+    Returns:
+        The result of the application or comparison.
+    """
     if callable(q):
         return q(v, *args)
     else:
@@ -13,6 +26,11 @@ def repr(self) -> str:
 
 
 class Regexp(object):
+    """A callable object that performs a regular expression search.
+
+    Attributes:
+        args: The compiled regular expression pattern.
+    """
     __repr__ = repr
 
     def __init__(self, rx) -> None:
@@ -25,6 +43,10 @@ class Regexp(object):
 
 
 class Any(object):
+    """A callable object that always returns True.
+
+    Useful as a wildcard or placeholder in queries.
+    """
     def __repr__(self) -> str:
         return "<{self.__class__.__name__}>".format(self=self)
 
@@ -36,6 +58,11 @@ ANY = Any()
 
 
 class Not(object):
+    """A callable object that negates the result of applying another query.
+
+    Attributes:
+        args: The query object whose result will be negated.
+    """
     __repr__ = repr
 
     def __init__(self, value) -> None:
@@ -46,6 +73,13 @@ class Not(object):
 
 
 class Or(object):
+    """A callable object that performs a logical OR operation on multiple queries.
+
+    It returns True if any of the provided queries return True when applied to the value.
+
+    Attributes:
+        args: A list or tuple of query objects.
+    """
     __repr__ = repr
 
     def __init__(self, args) -> None:
@@ -59,6 +93,13 @@ class Or(object):
 
 
 class And(object):
+    """A callable object that performs a logical AND operation on multiple queries.
+
+    It returns True if all of the provided queries return True when applied to the value.
+
+    Attributes:
+        args: A list or tuple of query objects.
+    """
     __repr__ = repr
 
     def __init__(self, args) -> None:

--- a/src/dictknife/pp.py
+++ b/src/dictknife/pp.py
@@ -5,6 +5,15 @@ from typing import Optional
 
 
 def pp(d, out=None) -> None:
+    """Pretty prints a dictionary-like object to the specified output stream.
+
+    It uses JSON formatting with indentation and sorted keys (if possible).
+
+    Args:
+        d: The dictionary-like object to print.
+        out (file-like object, optional): The output stream.
+            Defaults to sys.stdout.
+    """
     import json
 
     out = out or sys.stdout

--- a/src/dictknife/shape.py
+++ b/src/dictknife/shape.py
@@ -109,6 +109,32 @@ def shape(
     separator: str = "/",
     transform=as_jsonpointer,
 ):
+    """Generates a summary of the structure (shape) of a dictionary-like object.
+
+    It traverses the input object and identifies the paths to all elements,
+    along with their types and an example value.
+
+    Args:
+        d: The dictionary-like object to analyze.
+        traverse (callable, optional): A function that traverses the input object
+            and returns an intermediate representation (_State object).
+            Defaults to Traverser().traverse.
+        aggregate (callable, optional): A function that processes the intermediate
+            representation and returns the final list of Row namedtuples.
+            Defaults to _build_pathlist_from_state.
+        squash (bool, optional): If True, removes the initial "[]" from paths
+            if the root is a list. Defaults to False.
+        skiplist (bool, optional): If True, skips paths that end with "[]" (lists themselves).
+            Defaults to False.
+        separator (str, optional): The separator character to use when joining path segments.
+            Defaults to "/".
+        transform (callable, optional): A function to transform each path segment before joining.
+            Defaults to `as_jsonpointer`.
+
+    Returns:
+        list[Row]: A list of Row namedtuples, where each Row represents a unique path
+                   and contains `path` (str), `type` (list of types), and `example` (value).
+    """
     return aggregate(
         traverse(d),
         squash=squash,

--- a/src/dictknife/walkers.py
+++ b/src/dictknife/walkers.py
@@ -52,6 +52,13 @@ class DataHandler(object):
 
 
 class DictWalker(object):
+    """Walks through a dictionary-like object and yields values based on a query.
+
+    Attributes:
+        qs: A list of query objects that specify the path to the desired values.
+        handler: A handler object that processes the found values.
+        context_factory: A factory function that creates a context object for the walk.
+    """
     context_factory = PathContext
     handler_factory = ContainerHandler
 


### PR DESCRIPTION
Add English docstrings to all functions and classes imported in src/dictknife/__init__.py. This improves the usability and maintainability of the library by providing clear documentation for its public interface.